### PR TITLE
Add interactive Canvas widget builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
-# canvasdesigner
-Interactive activities to embed on Canvas
+# Canvas Designer
+
+Canvas Designer is a lightweight, browser-based builder for creating interactive elements that can be pasted straight into a Canvas LMS page. The tool currently supports two activity types:
+
+- **Flip cards** – great for quick knowledge checks or revealing layered information.
+- **Image hotspots** – upload any hosted image, drop clickable markers, and describe each point.
+
+Every configuration change instantly refreshes the on-page preview and regenerates a ready-to-use embed snippet. Designs are saved to the browser's local storage so you can return later without losing your work.
+
+## Getting started
+
+1. Open `index.html` in your preferred browser (double-click it or serve the folder via any static web server).
+2. Pick an interactive type from the Builder panel.
+3. Customize the settings. Hotspots can be added by clicking on the preview image or by using the **Add hotspot manually** button.
+4. Click **Save design** at any time to persist the setup in your browser.
+5. Copy the generated embed code and paste it into the Canvas LMS **HTML Editor**.
+
+> **Tip:** Use the keyboard shortcut **Ctrl/⌘+S** to quickly save your design.
+
+## Embed snippet notes
+
+- The embed code is completely self-contained (inline CSS + JS) and does not rely on external hosting or dependencies.
+- Each embed is namespaced with a unique ID so you can safely place multiple widgets on the same Canvas page.
+- Hotspot embeds require the image to be hosted somewhere publicly accessible (institutional CMS, Google Drive with sharing enabled, etc.).
+
+## Development
+
+This project is intentionally dependency-free. If you would like to extend it:
+
+1. Edit the HTML/CSS/JS files directly.
+2. Refresh the browser tab to see your changes.
+
+Feel free to adapt the builder to additional activity types or integrate it with a backend (Firebase credentials are provided in the task description) if persistent multi-user storage is required.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Canvas Designer - Interactive Embed Builder</title>
+    <link rel="stylesheet" href="styles/style.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <div class="header-content">
+        <h1>Canvas Designer</h1>
+        <p>Create and customize interactive widgets for Canvas LMS in minutes.</p>
+      </div>
+      <div class="header-actions">
+        <button id="newDesign" class="ghost">New design</button>
+        <button id="saveDesign" class="primary">Save design</button>
+      </div>
+    </header>
+
+    <main class="app-main">
+      <section class="controls">
+        <h2>Builder</h2>
+        <div class="field">
+          <label for="widgetType">Interactive type</label>
+          <select id="widgetType">
+            <option value="flip-card">Flip card</option>
+            <option value="hotspot">Image hotspots</option>
+          </select>
+        </div>
+
+        <section id="flipCardControls" class="control-group" hidden>
+          <h3>Flip card settings</h3>
+          <div class="field">
+            <label for="flipCardWidth">Width (px)</label>
+            <input type="number" id="flipCardWidth" min="160" value="320" />
+          </div>
+          <div class="field">
+            <label for="flipCardHeight">Height (px)</label>
+            <input type="number" id="flipCardHeight" min="160" value="200" />
+          </div>
+          <div class="field">
+            <label for="flipFrontText">Front text</label>
+            <textarea id="flipFrontText" rows="3" placeholder="Introduce the concept or ask a question"></textarea>
+          </div>
+          <div class="field">
+            <label for="flipBackText">Back text</label>
+            <textarea id="flipBackText" rows="3" placeholder="Reveal additional information or the answer"></textarea>
+          </div>
+          <div class="split">
+            <div class="field">
+              <label for="flipFrontColor">Front background</label>
+              <input type="color" id="flipFrontColor" value="#1b9aaa" />
+            </div>
+            <div class="field">
+              <label for="flipBackColor">Back background</label>
+              <input type="color" id="flipBackColor" value="#ef767a" />
+            </div>
+          </div>
+          <div class="split">
+            <div class="field">
+              <label for="flipFrontTextColor">Front text color</label>
+              <input type="color" id="flipFrontTextColor" value="#ffffff" />
+            </div>
+            <div class="field">
+              <label for="flipBackTextColor">Back text color</label>
+              <input type="color" id="flipBackTextColor" value="#ffffff" />
+            </div>
+          </div>
+        </section>
+
+        <section id="hotspotControls" class="control-group" hidden>
+          <h3>Hotspot settings</h3>
+          <div class="field">
+            <label for="hotspotImageUrl">Image URL</label>
+            <input
+              type="url"
+              id="hotspotImageUrl"
+              placeholder="Paste an image URL (must be publicly accessible)"
+            />
+          </div>
+          <p class="hint">
+            Tip: After the image loads, click anywhere on the preview to add a hotspot.
+          </p>
+          <div class="field">
+            <label for="hotspotTheme">Theme</label>
+            <select id="hotspotTheme">
+              <option value="light">Light</option>
+              <option value="dark">Dark</option>
+            </select>
+          </div>
+          <button type="button" id="addHotspot" class="ghost full-width">Add hotspot manually</button>
+          <div class="hotspot-list" id="hotspotList"></div>
+        </section>
+      </section>
+
+      <section class="preview">
+        <div class="preview-header">
+          <h2>Live preview</h2>
+          <button id="refreshPreview" class="ghost">Refresh</button>
+        </div>
+        <div id="previewCanvas" class="preview-canvas">
+          <div class="placeholder">
+            Choose an interactive type and start customizing to see the preview.
+          </div>
+        </div>
+      </section>
+
+      <section class="embed">
+        <div class="embed-header">
+          <h2>Embed code</h2>
+          <button id="copyEmbed" class="ghost">Copy</button>
+        </div>
+        <textarea id="embedCode" readonly></textarea>
+        <p class="hint">
+          Paste this code into the Canvas LMS <strong>HTML Editor</strong> to add the widget to your page.
+        </p>
+      </section>
+    </main>
+
+    <template id="hotspotRowTemplate">
+      <div class="hotspot-row">
+        <div class="hotspot-label">Hotspot <span class="hotspot-index"></span></div>
+        <div class="field">
+          <label>Title</label>
+          <input type="text" class="hotspot-title" placeholder="Label shown on hover" />
+        </div>
+        <div class="field">
+          <label>Description</label>
+          <textarea class="hotspot-description" rows="2" placeholder="Details shown on click"></textarea>
+        </div>
+        <div class="field split">
+          <div>
+            <label>X (%)</label>
+            <input type="number" class="hotspot-x" min="0" max="100" />
+          </div>
+          <div>
+            <label>Y (%)</label>
+            <input type="number" class="hotspot-y" min="0" max="100" />
+          </div>
+        </div>
+        <div class="row-actions">
+          <button type="button" class="ghost remove-hotspot">Remove</button>
+        </div>
+      </div>
+    </template>
+
+    <div id="toast" role="status" aria-live="polite"></div>
+
+    <script type="module" src="scripts/main.js"></script>
+  </body>
+</html>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,0 +1,673 @@
+const STORAGE_KEY = 'canvasdesigner-state';
+
+const clone = (value) => JSON.parse(JSON.stringify(value));
+
+const defaultState = {
+  widgetType: 'flip-card',
+  flipCard: {
+    width: 320,
+    height: 200,
+    frontText: '',
+    backText: '',
+    frontColor: '#1b9aaa',
+    backColor: '#ef767a',
+    frontTextColor: '#ffffff',
+    backTextColor: '#ffffff'
+  },
+  hotspot: {
+    imageUrl: '',
+    theme: 'light',
+    hotspots: []
+  }
+};
+
+let state = loadState();
+let hotspotIdCounter = state.hotspot.hotspots.reduce((max, spot) => Math.max(max, spot.id || 0), 0);
+
+const els = {
+  widgetType: document.getElementById('widgetType'),
+  flipCardControls: document.getElementById('flipCardControls'),
+  hotspotControls: document.getElementById('hotspotControls'),
+  previewCanvas: document.getElementById('previewCanvas'),
+  embedCode: document.getElementById('embedCode'),
+  refreshPreview: document.getElementById('refreshPreview'),
+  saveDesign: document.getElementById('saveDesign'),
+  newDesign: document.getElementById('newDesign'),
+  copyEmbed: document.getElementById('copyEmbed'),
+  toast: document.getElementById('toast'),
+  hotspotList: document.getElementById('hotspotList'),
+  hotspotRowTemplate: document.getElementById('hotspotRowTemplate'),
+  addHotspot: document.getElementById('addHotspot')
+};
+
+const flipCardFields = {
+  width: document.getElementById('flipCardWidth'),
+  height: document.getElementById('flipCardHeight'),
+  frontText: document.getElementById('flipFrontText'),
+  backText: document.getElementById('flipBackText'),
+  frontColor: document.getElementById('flipFrontColor'),
+  backColor: document.getElementById('flipBackColor'),
+  frontTextColor: document.getElementById('flipFrontTextColor'),
+  backTextColor: document.getElementById('flipBackTextColor')
+};
+
+const hotspotFields = {
+  imageUrl: document.getElementById('hotspotImageUrl'),
+  theme: document.getElementById('hotspotTheme')
+};
+
+function loadState() {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) return clone(defaultState);
+    const parsed = JSON.parse(stored);
+    const widgetType = ['flip-card', 'hotspot'].includes(parsed.widgetType)
+      ? parsed.widgetType
+      : defaultState.widgetType;
+
+    return {
+      widgetType,
+      flipCard: { ...defaultState.flipCard, ...(parsed.flipCard || {}) },
+      hotspot: {
+        ...defaultState.hotspot,
+        ...(parsed.hotspot || {}),
+        theme: ['light', 'dark'].includes(parsed?.hotspot?.theme)
+          ? parsed.hotspot.theme
+          : defaultState.hotspot.theme,
+        hotspots: Array.isArray(parsed?.hotspot?.hotspots)
+          ? parsed.hotspot.hotspots.map((spot, index) => ({
+              id: spot.id ?? index + 1,
+              title: spot.title || '',
+              description: spot.description || '',
+              x: typeof spot.x === 'number' ? spot.x : 50,
+              y: typeof spot.y === 'number' ? spot.y : 50
+            }))
+          : []
+      }
+    };
+  } catch (err) {
+    console.warn('Unable to load saved design, using defaults.', err);
+    return clone(defaultState);
+  }
+}
+
+function persistState() {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    showToast('Design saved in this browser.');
+  } catch (err) {
+    console.error('Unable to save design', err);
+    showToast('Unable to save design (storage may be full).');
+  }
+}
+
+function resetState() {
+  state = clone(defaultState);
+  hotspotIdCounter = 0;
+  applyStateToControls();
+  renderHotspotList();
+  renderPreview();
+  updateEmbedCode();
+  showToast('Started a fresh design.');
+}
+
+function applyStateToControls() {
+  els.widgetType.value = state.widgetType;
+
+  Object.entries(flipCardFields).forEach(([key, input]) => {
+    input.value = state.flipCard[key];
+  });
+
+  hotspotFields.imageUrl.value = state.hotspot.imageUrl;
+  hotspotFields.theme.value = state.hotspot.theme;
+
+  toggleControlGroups();
+}
+
+function toggleControlGroups() {
+  const isFlipCard = state.widgetType === 'flip-card';
+  els.flipCardControls.hidden = !isFlipCard;
+  els.hotspotControls.hidden = isFlipCard;
+}
+
+function showToast(message) {
+  if (!els.toast) return;
+  els.toast.textContent = message;
+  els.toast.classList.add('visible');
+  clearTimeout(showToast.timeoutId);
+  showToast.timeoutId = setTimeout(() => {
+    els.toast.classList.remove('visible');
+  }, 3200);
+}
+
+function handleWidgetTypeChange() {
+  state.widgetType = els.widgetType.value;
+  toggleControlGroups();
+  renderPreview();
+  updateEmbedCode();
+}
+
+function bindFlipCardEvents() {
+  Object.entries(flipCardFields).forEach(([key, input]) => {
+    input.addEventListener('input', () => {
+      const value = input.type === 'number' ? parseInt(input.value, 10) : input.value;
+      state.flipCard[key] = Number.isNaN(value) ? state.flipCard[key] : value;
+      if (input.type !== 'number') {
+        state.flipCard[key] = input.value;
+      }
+      renderPreview();
+      updateEmbedCode();
+    });
+  });
+}
+
+function bindHotspotEvents() {
+  hotspotFields.imageUrl.addEventListener('change', () => {
+    state.hotspot.imageUrl = hotspotFields.imageUrl.value.trim();
+    renderPreview();
+    updateEmbedCode();
+  });
+
+  hotspotFields.theme.addEventListener('change', () => {
+    state.hotspot.theme = hotspotFields.theme.value;
+    renderPreview();
+    updateEmbedCode();
+  });
+
+  if (els.addHotspot) {
+    els.addHotspot.addEventListener('click', () => {
+      if (!state.hotspot.imageUrl) {
+        showToast('Add an image URL before creating hotspots.');
+        return;
+      }
+      addHotspot({ x: 50, y: 50 });
+    });
+  }
+}
+
+function renderHotspotList() {
+  els.hotspotList.innerHTML = '';
+  if (state.hotspot.hotspots.length === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'empty-state';
+    empty.textContent = 'No hotspots yet. Add one from the preview or with the button above.';
+    els.hotspotList.appendChild(empty);
+    return;
+  }
+  state.hotspot.hotspots.forEach((spot, index) => {
+    const fragment = els.hotspotRowTemplate.content.cloneNode(true);
+    const row = fragment.querySelector('.hotspot-row');
+    row.dataset.id = spot.id;
+    row.querySelector('.hotspot-index').textContent = index + 1;
+    const titleInput = row.querySelector('.hotspot-title');
+    const descriptionInput = row.querySelector('.hotspot-description');
+    const xInput = row.querySelector('.hotspot-x');
+    const yInput = row.querySelector('.hotspot-y');
+
+    titleInput.value = spot.title;
+    descriptionInput.value = spot.description;
+    xInput.value = spot.x;
+    yInput.value = spot.y;
+
+    titleInput.addEventListener('input', () => updateHotspot(spot.id, { title: titleInput.value }));
+    descriptionInput.addEventListener('input', () =>
+      updateHotspot(spot.id, { description: descriptionInput.value })
+    );
+    xInput.addEventListener('input', () => updateHotspot(spot.id, { x: clampPercent(xInput.value) }));
+    yInput.addEventListener('input', () => updateHotspot(spot.id, { y: clampPercent(yInput.value) }));
+    row.querySelector('.remove-hotspot').addEventListener('click', () => removeHotspot(spot.id));
+
+    els.hotspotList.appendChild(fragment);
+  });
+}
+
+function clampPercent(value) {
+  const number = typeof value === 'number' ? value : parseFloat(value);
+  if (Number.isNaN(number)) return 0;
+  return Math.min(100, Math.max(0, Math.round(number * 10) / 10));
+}
+
+function updateHotspot(id, updates) {
+  const hotspot = state.hotspot.hotspots.find((spot) => spot.id === id);
+  if (!hotspot) return;
+  Object.assign(hotspot, updates);
+  renderPreview();
+  updateEmbedCode();
+}
+
+function removeHotspot(id) {
+  state.hotspot.hotspots = state.hotspot.hotspots.filter((spot) => spot.id !== id);
+  renderHotspotList();
+  renderPreview();
+  updateEmbedCode();
+}
+
+function addHotspotFromClick(event, mapEl) {
+  const rect = mapEl.getBoundingClientRect();
+  const xPercent = ((event.clientX - rect.left) / rect.width) * 100;
+  const yPercent = ((event.clientY - rect.top) / rect.height) * 100;
+  addHotspot({
+    x: Math.round(xPercent * 10) / 10,
+    y: Math.round(yPercent * 10) / 10
+  });
+}
+
+function addHotspot({ x, y }) {
+  hotspotIdCounter += 1;
+  const newHotspot = {
+    id: hotspotIdCounter,
+    title: `Hotspot ${state.hotspot.hotspots.length + 1}`,
+    description: 'Describe this point...',
+    x: typeof x === 'number' ? clampPercent(x) : 50,
+    y: typeof y === 'number' ? clampPercent(y) : 50
+  };
+  state.hotspot.hotspots.push(newHotspot);
+  renderHotspotList();
+  renderPreview();
+  updateEmbedCode();
+  showToast('Added a hotspot. Update the details from the list.');
+}
+
+function renderPreview() {
+  els.previewCanvas.innerHTML = '';
+
+  if (state.widgetType === 'flip-card') {
+    els.previewCanvas.appendChild(createFlipCardPreview(state.flipCard));
+  } else if (state.widgetType === 'hotspot') {
+    if (!state.hotspot.imageUrl) {
+      const placeholder = document.createElement('div');
+      placeholder.className = 'placeholder';
+      placeholder.textContent = 'Paste an image URL to start placing hotspots.';
+      els.previewCanvas.appendChild(placeholder);
+      return;
+    }
+    const { element, mapEl } = createHotspotPreview(state.hotspot);
+    els.previewCanvas.appendChild(element);
+    mapEl.addEventListener('click', (event) => {
+      if (event.target.closest('.canvasd-hotspot')) return;
+      addHotspotFromClick(event, mapEl);
+    });
+  }
+}
+
+function createFlipCardPreview(config) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'flip-card-wrapper';
+  const card = document.createElement('div');
+  card.className = 'canvasd-flip-card';
+  card.style.setProperty('--flip-width', `${config.width}px`);
+  card.style.setProperty('--flip-height', `${config.height}px`);
+
+  const inner = document.createElement('div');
+  inner.className = 'canvasd-flip-card-inner';
+
+  const front = document.createElement('div');
+  front.className = 'canvasd-flip-face front';
+  front.style.background = config.frontColor;
+  front.style.color = config.frontTextColor;
+  front.innerHTML = formatMultiline(escapeHTML(config.frontText || 'Front side content'));
+
+  const back = document.createElement('div');
+  back.className = 'canvasd-flip-face back';
+  back.style.background = config.backColor;
+  back.style.color = config.backTextColor;
+  back.innerHTML = formatMultiline(escapeHTML(config.backText || 'Back side content'));
+
+  const toggle = document.createElement('button');
+  toggle.type = 'button';
+  toggle.className = 'flip-toggle';
+  toggle.textContent = 'Flip';
+
+  inner.appendChild(front);
+  inner.appendChild(back);
+  card.appendChild(inner);
+  card.appendChild(toggle);
+  wrapper.appendChild(card);
+
+  const toggleFlip = (event) => {
+    event?.stopPropagation();
+    card.classList.toggle('is-flipped');
+  };
+
+  card.addEventListener('click', toggleFlip);
+  toggle.addEventListener('click', toggleFlip);
+
+  return wrapper;
+}
+
+function createHotspotPreview(config) {
+  const wrapper = document.createElement('div');
+  wrapper.className = 'canvasd-hotspot-wrapper';
+
+  const map = document.createElement('div');
+  map.className = 'canvasd-hotspot-map';
+
+  const img = document.createElement('img');
+  img.src = config.imageUrl;
+  img.alt = '';
+
+  map.appendChild(img);
+
+  config.hotspots.forEach((spot, index) => {
+    map.appendChild(createHotspotElement(spot, index, config.theme));
+  });
+
+  wrapper.appendChild(map);
+
+  return { element: wrapper, mapEl: map };
+}
+
+function createHotspotElement(spot, index, theme) {
+  const hotspot = document.createElement('button');
+  hotspot.type = 'button';
+  hotspot.className = `canvasd-hotspot ${theme === 'dark' ? 'dark' : ''}`.trim();
+  hotspot.style.left = `${spot.x}%`;
+  hotspot.style.top = `${spot.y}%`;
+  hotspot.setAttribute('aria-label', `${spot.title || `Hotspot ${index + 1}`}`);
+  hotspot.title = spot.title || `Hotspot ${index + 1}`;
+  hotspot.innerHTML = `<span>${index + 1}</span>`;
+
+  const tooltip = document.createElement('div');
+  tooltip.className = 'canvasd-hotspot-tooltip';
+  tooltip.innerHTML = `
+    <h4>${escapeHTML(spot.title || `Hotspot ${index + 1}`)}</h4>
+    <p>${escapeHTML(spot.description || 'Add a description to explain this point.')}</p>
+  `;
+
+  hotspot.appendChild(tooltip);
+  hotspot.addEventListener('click', (event) => {
+    event.stopPropagation();
+    hotspot.classList.toggle('is-active');
+  });
+
+  return hotspot;
+}
+
+function updateEmbedCode() {
+  let code = '';
+  if (state.widgetType === 'flip-card') {
+    code = generateFlipCardEmbed(state.flipCard);
+  } else if (state.widgetType === 'hotspot') {
+    code = generateHotspotEmbed(state.hotspot);
+  }
+  els.embedCode.value = code.trim();
+}
+
+function generateFlipCardEmbed(config) {
+  const id = `canvasd-flip-${Date.now()}`;
+  const front = formatMultiline(escapeHTML(config.frontText || 'Front side content'));
+  const back = formatMultiline(escapeHTML(config.backText || 'Back side content'));
+
+  return `
+<div id="${id}" class="canvasd-embed">
+  <style>
+    #${id} {
+      display: inline-block;
+      perspective: 1600px;
+    }
+    #${id} .canvasd-flip-card {
+      position: relative;
+      width: ${config.width}px;
+      height: ${config.height}px;
+    }
+    #${id} .canvasd-flip-card-inner {
+      position: relative;
+      width: 100%;
+      height: 100%;
+      transition: transform 0.8s;
+      transform-style: preserve-3d;
+    }
+    #${id} .canvasd-flip-card.is-flipped .canvasd-flip-card-inner {
+      transform: rotateY(180deg);
+    }
+    #${id} .canvasd-flip-face {
+      position: absolute;
+      width: 100%;
+      height: 100%;
+      border-radius: 16px;
+      backface-visibility: hidden;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 1.5rem;
+      font-size: 1rem;
+      line-height: 1.5;
+      box-shadow: 0 18px 40px rgba(15, 23, 42, 0.35);
+    }
+    #${id} .canvasd-flip-face.back {
+      transform: rotateY(180deg);
+    }
+    #${id} .flip-toggle {
+      position: absolute;
+      bottom: 1.25rem;
+      right: 1.25rem;
+      background: rgba(15, 23, 42, 0.65);
+      color: #fff;
+      border: none;
+      border-radius: 999px;
+      padding: 0.45rem 1rem;
+      font-size: 0.78rem;
+      font-weight: 600;
+      cursor: pointer;
+    }
+  </style>
+  <div class="canvasd-flip-card">
+    <div class="canvasd-flip-card-inner">
+      <div class="canvasd-flip-face front" style="background: ${config.frontColor}; color: ${config.frontTextColor};">
+        ${front}
+      </div>
+      <div class="canvasd-flip-face back" style="background: ${config.backColor}; color: ${config.backTextColor};">
+        ${back}
+      </div>
+    </div>
+    <button type="button" class="flip-toggle">Flip</button>
+  </div>
+  <script>
+    (function() {
+      const root = document.getElementById('${id}');
+      if (!root) return;
+      const card = root.querySelector('.canvasd-flip-card');
+      const toggle = root.querySelector('.flip-toggle');
+      const toggleFlip = function(event) {
+        event?.stopPropagation();
+        card.classList.toggle('is-flipped');
+      };
+      card.addEventListener('click', toggleFlip);
+      toggle.addEventListener('click', toggleFlip);
+    })();
+  </script>
+</div>
+`.trim();
+}
+
+function generateHotspotEmbed(config) {
+  if (!config.imageUrl) {
+    return '<!-- Add an image URL to generate hotspot embed code -->';
+  }
+
+  const id = `canvasd-hotspot-${Date.now()}`;
+  const hotspotsHtml = config.hotspots
+    .map((spot, index) => {
+      const title = escapeHTML(spot.title || `Hotspot ${index + 1}`);
+      const description = escapeHTML(spot.description || 'Describe this point.');
+      return `
+      <button type="button" class="canvasd-hotspot ${config.theme === 'dark' ? 'dark' : ''}" style="left: ${spot.x}%; top: ${spot.y}%;" aria-label="${title}" title="${title}">
+        <span>${index + 1}</span>
+        <div class="canvasd-hotspot-tooltip">
+          <h4>${title}</h4>
+          <p>${description}</p>
+        </div>
+      </button>`;
+    })
+    .join('');
+
+  return `
+<div id="${id}" class="canvasd-embed">
+  <style>
+    #${id} {
+      display: inline-block;
+      position: relative;
+      max-width: 100%;
+      font-family: 'Inter', 'Segoe UI', system-ui, sans-serif;
+    }
+    #${id} .canvasd-hotspot-map {
+      position: relative;
+      border-radius: 16px;
+      overflow: hidden;
+    }
+    #${id} img {
+      display: block;
+      width: 100%;
+      height: auto;
+    }
+    #${id} .canvasd-hotspot {
+      position: absolute;
+      width: 32px;
+      height: 32px;
+      border-radius: 999px;
+      display: grid;
+      place-items: center;
+      font-size: 0.75rem;
+      font-weight: 700;
+      cursor: pointer;
+      transform: translate(-50%, -50%);
+      border: 2px solid rgba(255, 255, 255, 0.8);
+      background: linear-gradient(135deg, rgba(37, 99, 235, 0.95), rgba(59, 130, 246, 0.95));
+      color: white;
+      box-shadow: 0 12px 30px rgba(15, 23, 42, 0.45);
+      transition: transform 0.2s ease;
+    }
+    #${id} .canvasd-hotspot.dark {
+      background: linear-gradient(135deg, rgba(30, 64, 175, 0.9), rgba(79, 70, 229, 0.95));
+      border-color: rgba(15, 23, 42, 0.6);
+    }
+    #${id} .canvasd-hotspot:hover {
+      transform: translate(-50%, -50%) scale(1.05);
+    }
+    #${id} .canvasd-hotspot-tooltip {
+      position: absolute;
+      min-width: 200px;
+      max-width: 260px;
+      background: rgba(15, 23, 42, 0.92);
+      color: rgba(226, 232, 240, 0.95);
+      border-radius: 12px;
+      padding: 1rem;
+      border: 1px solid rgba(148, 163, 184, 0.35);
+      box-shadow: 0 22px 40px rgba(15, 23, 42, 0.45);
+      transform: translate(-50%, calc(-100% - 22px));
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.2s ease;
+      z-index: 5;
+    }
+    #${id} .canvasd-hotspot.is-active .canvasd-hotspot-tooltip,
+    #${id} .canvasd-hotspot:hover .canvasd-hotspot-tooltip {
+      opacity: 1;
+    }
+    #${id} .canvasd-hotspot-tooltip::after {
+      content: '';
+      position: absolute;
+      width: 12px;
+      height: 12px;
+      background: inherit;
+      border-left: inherit;
+      border-bottom: inherit;
+      bottom: -6px;
+      left: 50%;
+      transform: translateX(-50%) rotate(45deg);
+    }
+  </style>
+  <div class="canvasd-hotspot-map">
+    <img src="${escapeAttribute(config.imageUrl)}" alt="Hotspot map" />
+    ${hotspotsHtml}
+  </div>
+  <script>
+    (function() {
+      const root = document.getElementById('${id}');
+      if (!root) return;
+      const hotspots = Array.from(root.querySelectorAll('.canvasd-hotspot'));
+      hotspots.forEach((spot) => {
+        spot.addEventListener('click', function(event) {
+          event.stopPropagation();
+          const alreadyActive = spot.classList.contains('is-active');
+          hotspots.forEach((other) => other.classList.remove('is-active'));
+          if (!alreadyActive) {
+            spot.classList.add('is-active');
+          }
+        });
+      });
+      document.addEventListener('click', function(event) {
+        if (!root.contains(event.target)) {
+          hotspots.forEach((spot) => spot.classList.remove('is-active'));
+        }
+      });
+    })();
+  </script>
+</div>
+`.trim();
+}
+
+function formatMultiline(text) {
+  if (!text) return '';
+  return text
+    .split('\n')
+    .map((line) => `<p>${line || '&nbsp;'}</p>`)
+    .join('');
+}
+
+function escapeHTML(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function escapeAttribute(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;');
+}
+
+function bindGlobalActions() {
+  els.refreshPreview.addEventListener('click', renderPreview);
+  els.saveDesign.addEventListener('click', persistState);
+  els.newDesign.addEventListener('click', () => {
+    if (confirm('Start a new design? Unsaved changes will be lost.')) {
+      resetState();
+    }
+  });
+
+  els.copyEmbed.addEventListener('click', async () => {
+    try {
+      await navigator.clipboard.writeText(els.embedCode.value);
+      showToast('Embed code copied to clipboard.');
+    } catch (err) {
+      console.error('Clipboard copy failed', err);
+      showToast('Select the embed code and copy it manually (Ctrl/Cmd+C).');
+    }
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 's' && (event.metaKey || event.ctrlKey)) {
+      event.preventDefault();
+      persistState();
+    }
+  });
+}
+
+function initialize() {
+  applyStateToControls();
+  bindFlipCardEvents();
+  bindHotspotEvents();
+  bindGlobalActions();
+  renderHotspotList();
+  renderPreview();
+  updateEmbedCode();
+
+  els.widgetType.addEventListener('change', handleWidgetTypeChange);
+}
+
+initialize();

--- a/styles/style.css
+++ b/styles/style.css
@@ -1,0 +1,471 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  line-height: 1.4;
+  --bg: #0f172a;
+  --bg-soft: rgba(15, 23, 42, 0.7);
+  --panel: rgba(15, 23, 42, 0.9);
+  --panel-light: rgba(248, 250, 252, 0.9);
+  --text: #0f172a;
+  --text-light: #f1f5f9;
+  --accent: #2563eb;
+  --accent-soft: rgba(37, 99, 235, 0.15);
+  --border: rgba(148, 163, 184, 0.35);
+  --toast-bg: rgba(15, 23, 42, 0.9);
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top left, #1d4ed8, #111827);
+  color: var(--text-light);
+  display: flex;
+  flex-direction: column;
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 2.5rem;
+  background: rgba(15, 23, 42, 0.85);
+  backdrop-filter: blur(16px);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: 1.5rem;
+}
+
+.app-header p {
+  margin: 0.25rem 0 0;
+  color: rgba(226, 232, 240, 0.8);
+  max-width: 32rem;
+}
+
+.app-main {
+  display: grid;
+  grid-template-columns: minmax(280px, 340px) minmax(320px, 1fr) minmax(320px, 1fr);
+  gap: 1.5rem;
+  padding: 2rem;
+}
+
+section {
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 16px;
+  padding: 1.5rem;
+  backdrop-filter: blur(12px);
+  box-shadow: 0 24px 50px rgba(15, 23, 42, 0.4);
+}
+
+h2 {
+  font-size: 1.25rem;
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+h3 {
+  margin-top: 1.5rem;
+  margin-bottom: 1rem;
+  font-size: 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(148, 163, 184, 0.9);
+}
+
+.controls {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-bottom: 1rem;
+}
+
+.field label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  color: rgba(226, 232, 240, 0.85);
+}
+
+.field input,
+.field textarea,
+.field select {
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  padding: 0.6rem 0.75rem;
+  font: inherit;
+  background: rgba(15, 23, 42, 0.35);
+  color: var(--text-light);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.field input:focus,
+.field textarea:focus,
+.field select:focus {
+  outline: none;
+  border-color: rgba(37, 99, 235, 0.6);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.35);
+}
+
+textarea {
+  resize: vertical;
+}
+
+.split {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+button {
+  font: inherit;
+  border-radius: 999px;
+  border: none;
+  padding: 0.6rem 1.2rem;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+}
+
+button.primary {
+  background: linear-gradient(135deg, #2563eb, #9333ea);
+  color: white;
+  font-weight: 600;
+}
+
+button.primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 25px rgba(79, 70, 229, 0.45);
+}
+
+button.ghost {
+  background: rgba(148, 163, 184, 0.18);
+  color: rgba(226, 232, 240, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+button.ghost:hover {
+  background: rgba(148, 163, 184, 0.35);
+}
+
+button.full-width {
+  width: 100%;
+  justify-content: center;
+}
+
+.preview-header,
+.embed-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.preview-canvas {
+  margin-top: 1rem;
+  background: rgba(15, 23, 42, 0.45);
+  border-radius: 14px;
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  padding: 1.5rem;
+  min-height: 320px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+}
+
+.preview-canvas .placeholder {
+  text-align: center;
+  max-width: 18rem;
+  color: rgba(148, 163, 184, 0.85);
+  font-size: 0.95rem;
+}
+
+textarea#embedCode {
+  width: 100%;
+  min-height: 260px;
+  background: rgba(15, 23, 42, 0.45);
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  padding: 1rem;
+  color: rgba(226, 232, 240, 0.9);
+  font-family: 'JetBrains Mono', 'Fira Code', monospace;
+  font-size: 0.85rem;
+  line-height: 1.5;
+}
+
+.hint {
+  font-size: 0.8rem;
+  color: rgba(226, 232, 240, 0.6);
+  margin-top: -0.5rem;
+}
+
+.hotspot-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.empty-state {
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  border-radius: 12px;
+  padding: 1rem;
+  text-align: center;
+  font-size: 0.85rem;
+  color: rgba(226, 232, 240, 0.65);
+}
+
+.hotspot-row {
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 12px;
+  padding: 1rem;
+  background: rgba(15, 23, 42, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.hotspot-label {
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.85);
+}
+
+.row-actions {
+  display: flex;
+  justify-content: flex-end;
+}
+
+#toast {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  padding: 0.9rem 1.2rem;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  color: rgba(226, 232, 240, 0.9);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.4s ease, transform 0.4s ease;
+  transform: translateY(20px);
+  font-size: 0.9rem;
+  box-shadow: 0 16px 40px rgba(15, 23, 42, 0.4);
+}
+
+#toast.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+/* Flip card preview styles */
+.flip-card-wrapper {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.canvasd-flip-card {
+  perspective: 1600px;
+  width: var(--flip-width);
+  height: var(--flip-height);
+}
+
+.canvasd-flip-card-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  text-align: center;
+  transition: transform 0.8s;
+  transform-style: preserve-3d;
+}
+
+.canvasd-flip-card.is-flipped .canvasd-flip-card-inner {
+  transform: rotateY(180deg);
+}
+
+.canvasd-flip-face {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  border-radius: 16px;
+  backface-visibility: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  font-size: 1.05rem;
+  line-height: 1.45;
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.35);
+}
+
+.canvasd-flip-face.back {
+  transform: rotateY(180deg);
+}
+
+.canvasd-flip-card button.flip-toggle {
+  position: absolute;
+  bottom: 1.25rem;
+  right: 1.25rem;
+  background: rgba(0, 0, 0, 0.35);
+  border-radius: 999px;
+  padding: 0.4rem 0.8rem;
+  color: white;
+  font-size: 0.75rem;
+  font-weight: 600;
+  border: none;
+}
+
+.canvasd-flip-card button.flip-toggle:hover {
+  background: rgba(0, 0, 0, 0.55);
+}
+
+/* Hotspot widget */
+.canvasd-hotspot-wrapper {
+  width: 100%;
+  display: flex;
+  justify-content: center;
+}
+
+.canvasd-hotspot-map {
+  position: relative;
+  border-radius: 16px;
+  overflow: hidden;
+  max-width: 100%;
+}
+
+.canvasd-hotspot-map img {
+  display: block;
+  max-width: 100%;
+  height: auto;
+}
+
+.canvasd-hotspot {
+  position: absolute;
+  width: 32px;
+  height: 32px;
+  border-radius: 999px;
+  display: grid;
+  place-items: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+  cursor: pointer;
+  transform: translate(-50%, -50%);
+  border: 2px solid rgba(255, 255, 255, 0.8);
+  background: linear-gradient(135deg, rgba(37, 99, 235, 0.95), rgba(59, 130, 246, 0.95));
+  color: white;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.45);
+  transition: transform 0.25s ease;
+}
+
+.canvasd-hotspot:hover {
+  transform: translate(-50%, -50%) scale(1.05);
+}
+
+.canvasd-hotspot.dark {
+  background: linear-gradient(135deg, rgba(30, 64, 175, 0.9), rgba(79, 70, 229, 0.95));
+  border-color: rgba(15, 23, 42, 0.65);
+}
+
+.canvasd-hotspot-tooltip {
+  position: absolute;
+  min-width: 220px;
+  max-width: 260px;
+  background: rgba(15, 23, 42, 0.92);
+  color: rgba(226, 232, 240, 0.95);
+  border-radius: 12px;
+  padding: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 0 22px 40px rgba(15, 23, 42, 0.45);
+  transform: translate(-50%, calc(-100% - 22px));
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+  z-index: 5;
+}
+
+.canvasd-hotspot:hover .canvasd-hotspot-tooltip,
+.canvasd-hotspot.is-active .canvasd-hotspot-tooltip {
+  opacity: 1;
+}
+
+.canvasd-hotspot-tooltip h4 {
+  margin: 0 0 0.4rem;
+  font-size: 0.95rem;
+}
+
+.canvasd-hotspot-tooltip p {
+  margin: 0;
+  font-size: 0.8rem;
+  line-height: 1.5;
+}
+
+.canvasd-hotspot-tooltip::after {
+  content: '';
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  background: inherit;
+  border-left: inherit;
+  border-bottom: inherit;
+  bottom: -6px;
+  left: 50%;
+  transform: translateX(-50%) rotate(45deg);
+}
+
+.embed textarea {
+  font-size: 0.78rem;
+}
+
+@media (max-width: 1200px) {
+  .app-main {
+    grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
+    grid-template-rows: auto auto;
+  }
+
+  .preview {
+    grid-column: span 2;
+  }
+
+  .embed {
+    grid-column: span 2;
+  }
+}
+
+@media (max-width: 768px) {
+  body {
+    background: #0f172a;
+  }
+
+  .app-header {
+    flex-direction: column;
+    gap: 1rem;
+    text-align: center;
+  }
+
+  .app-main {
+    grid-template-columns: 1fr;
+    padding: 1.5rem;
+  }
+
+  section {
+    padding: 1.25rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a single-page Canvas Designer interface with controls for flip cards and image hotspot widgets
- implement live previews, local storage persistence, and self-contained embed code generation for each widget type
- refresh project README with usage instructions and tips for embedding in Canvas

## Testing
- not run (static site with no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d385b17310832b9558b2158a1fc305