### PR TITLE
Add preview toggle and local activity library

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,7 +56,15 @@
       </aside>
       <section class="preview-panel" aria-label="Interactive preview">
         <div class="preview-toolbar">
-          <h2 id="previewTitle">Preview</h2>
+          <div class="preview-toolbar-meta">
+            <h2 id="previewTitle">Preview</h2>
+            <div
+              class="preview-mode-toggle"
+              id="previewModeControls"
+              role="group"
+              aria-label="Preview mode"
+            ></div>
+          </div>
           <div class="preview-toolbar-actions" id="previewToolbar"></div>
         </div>
         <div id="instructionsPreview" class="instructions-preview" role="status"></div>
@@ -75,9 +83,18 @@
     <dialog id="loadDialog" aria-labelledby="loadDialogTitle">
       <form method="dialog" class="dialog-content">
         <h2 id="loadDialogTitle">Load saved activity</h2>
-        <p>Enter the activity code shared with you to continue editing.</p>
+        <p>Pick a saved interactive from this device or paste a share code.</p>
+        <section class="saved-activities" aria-labelledby="savedListHeading">
+          <div class="saved-activities-header">
+            <h3 id="savedListHeading">Saved on this device</h3>
+            <p id="savedEmpty" class="helper-text">Activities that you save will appear here.</p>
+          </div>
+          <ul id="savedActivityList" class="saved-activity-list"></ul>
+          <div id="savedActivityPreview" class="saved-activity-preview" aria-live="polite"></div>
+        </section>
+        <div class="divider" role="separator" aria-hidden="true"></div>
         <label for="loadId">Activity code</label>
-        <input id="loadId" name="loadId" type="text" required />
+        <input id="loadId" name="loadId" type="text" placeholder="Enter a share code" />
         <menu class="dialog-actions">
           <button value="cancel" type="reset">Cancel</button>
           <button value="confirm" type="submit">Load</button>

--- a/styles/main.css
+++ b/styles/main.css
@@ -84,6 +84,12 @@ body, button, input, select, textarea {
   font-weight: 600;
 }
 
+.helper-text {
+  font-size: 0.95rem;
+  color: #475569;
+  margin: 0;
+}
+
 .panel-section input,
 .panel-section textarea,
 .panel-section select {
@@ -116,20 +122,54 @@ body, button, input, select, textarea {
   gap: 1rem;
 }
 
+
 .preview-toolbar {
   display: flex;
   justify-content: space-between;
-  align-items: baseline;
-  gap: 1rem;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
 }
 
+.preview-toolbar-meta {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.preview-mode-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.25rem;
+  border-radius: 999px;
+  background: rgba(30, 64, 175, 0.08);
+}
+
+.preview-mode-toggle button {
+  border-radius: 999px;
+  background: transparent;
+  border: none;
+  color: inherit;
+  padding: 0.3rem 0.85rem;
+  font-weight: 600;
+}
+
+.preview-mode-toggle button.active {
+  background: #fff;
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.15);
+}
+
+
 .instructions-preview {
-  padding: 0.75rem 1rem;
-  background: var(--surface-alt);
-  border-radius: 0.75rem;
-  border: 1px dashed var(--border);
+  padding: 1rem 1.25rem;
+  background: linear-gradient(135deg, rgba(191, 219, 254, 0.45), rgba(239, 246, 255, 0.75));
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.5);
   font-style: italic;
   min-height: 3.75rem;
+  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.08);
 }
 
 .instructions-preview:empty::before {
@@ -137,13 +177,33 @@ body, button, input, select, textarea {
   color: #6b7280;
 }
 
+
 .preview-canvas {
   flex: 1;
-  border: 2px dashed #b8d1f0;
   border-radius: 1rem;
-  padding: clamp(1rem, 2vw, 2rem);
-  background: #f9fbff;
+  padding: clamp(0.5rem, 1.5vw, 1rem);
+  background: transparent;
   overflow: auto;
+}
+
+.preview-stage {
+  background: linear-gradient(160deg, #ffffff 0%, #f8fbff 60%, #eef4ff 100%);
+  border-radius: 1.25rem;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.15);
+  padding: clamp(1rem, 2vw, 2.25rem);
+  display: grid;
+  gap: 1.5rem;
+  min-height: 340px;
+}
+
+.preview-stage[data-mode="preview"] {
+  background: linear-gradient(135deg, #ffffff 0%, #f5f7ff 55%, #eef2ff 100%);
+  box-shadow: 0 22px 44px rgba(30, 64, 175, 0.18);
+}
+
+.preview-stage > *:first-child {
+  margin-top: 0;
 }
 
 .preview-canvas:focus-visible,
@@ -262,13 +322,14 @@ button.secondary {
 .flipcard button {
   width: 100%;
   height: 100%;
-  border-radius: 1rem;
-  border: 1px solid var(--border);
-  background: linear-gradient(160deg, #ffffff 0%, #e0f2ff 100%);
+  border-radius: 1.1rem;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  background: linear-gradient(155deg, rgba(255, 255, 255, 0.95) 0%, rgba(219, 234, 254, 0.95) 100%);
   display: grid;
   place-items: center;
-  padding: 1rem;
+  padding: 1.1rem;
   text-align: center;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
 }
 
 .flipcard .card-side {
@@ -295,12 +356,13 @@ button.secondary {
 }
 
 .accordion {
-  border-radius: 0.75rem;
-  border: 1px solid var(--border);
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.5);
   overflow: hidden;
   display: grid;
   gap: 1px;
-  background: var(--border);
+  background: rgba(148, 163, 184, 0.35);
+  box-shadow: 0 16px 30px rgba(15, 23, 42, 0.12);
 }
 
 .accordion button {
@@ -326,8 +388,8 @@ button.secondary {
 
 .dragdrop-stage {
   display: grid;
-  gap: 1rem;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
 }
 
 .dropzone,
@@ -335,11 +397,11 @@ button.secondary {
 .sortable-item,
 .hotspot-point,
 .timeline-event {
-  border-radius: 0.75rem;
-  border: 1px solid var(--border);
-  padding: 0.75rem;
+  border-radius: 0.85rem;
+  border: 1px solid rgba(148, 163, 184, 0.55);
+  padding: 0.85rem;
   background: #fff;
-  box-shadow: 0 4px 8px rgba(15, 23, 42, 0.05);
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.08);
 }
 
 .dropzone {
@@ -375,8 +437,8 @@ button.secondary {
 
 .hotspot-image-wrapper {
   position: relative;
-  border: 2px dashed var(--border);
-  border-radius: 1rem;
+  border: 2px dashed rgba(148, 163, 184, 0.65);
+  border-radius: 1.25rem;
   overflow: hidden;
   background: #e2e8f0;
   min-height: 240px;
@@ -557,11 +619,119 @@ button.secondary {
   font-style: italic;
 }
 
-.preview-panel .helper-text {
-  color: #475569;
-  font-size: 0.95rem;
-}
-
 .instructions-preview strong {
   font-weight: 600;
+}
+
+.divider {
+  height: 1px;
+  width: 100%;
+  background: linear-gradient(90deg, rgba(148, 163, 184, 0), rgba(148, 163, 184, 0.7), rgba(148, 163, 184, 0));
+  border-radius: 999px;
+  margin: 1rem 0;
+}
+
+.saved-activities {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.saved-activities-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 0.75rem;
+}
+
+.saved-activity-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.75rem;
+  max-height: 260px;
+  overflow-y: auto;
+}
+
+.saved-activity-item {
+  display: flex;
+  align-items: stretch;
+  gap: 0.5rem;
+}
+
+.saved-activity-button {
+  flex: 1;
+  text-align: left;
+  border-radius: 0.85rem;
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  background: rgba(255, 255, 255, 0.9);
+  padding: 0.75rem 1rem;
+  display: grid;
+  gap: 0.35rem;
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.1);
+}
+
+.saved-activity-button:hover,
+.saved-activity-button:focus-visible {
+  background: linear-gradient(135deg, rgba(191, 219, 254, 0.6), rgba(239, 246, 255, 0.9));
+}
+
+.saved-activity-title {
+  font-weight: 600;
+}
+
+.saved-activity-meta {
+  font-size: 0.9rem;
+  color: #475569;
+}
+
+.saved-activity-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: rgba(30, 64, 175, 0.15);
+  color: #1d4ed8;
+  border-radius: 999px;
+  padding: 0.1rem 0.55rem;
+  width: max-content;
+}
+
+.saved-activity-delete {
+  align-self: center;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  background: rgba(248, 250, 252, 0.9);
+  color: #1f2937;
+  padding: 0.45rem 0.85rem;
+  font-weight: 600;
+}
+
+.saved-activity-delete:hover,
+.saved-activity-delete:focus-visible {
+  background: rgba(254, 226, 226, 0.8);
+  border-color: rgba(248, 113, 113, 0.6);
+  color: #b91c1c;
+}
+
+.saved-activity-preview {
+  display: none;
+  border-radius: 0.85rem;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(255, 255, 255, 0.95);
+  padding: 0.85rem 1rem;
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.1);
+}
+
+.saved-activity-preview.active {
+  display: block;
+}
+
+.saved-activity-preview h4 {
+  margin: 0 0 0.35rem;
+}
+
+.saved-activity-preview p {
+  margin: 0 0 0.35rem;
 }


### PR DESCRIPTION
## Summary
- refresh the builder preview with an H5P-inspired stage and a build/preview mode toggle
- restyle interactive editing controls for a more polished, learner-like appearance
- add a local activity library with device storage, previews, and offline-friendly save/load handling

## Testing
- manual via browser

------
https://chatgpt.com/codex/tasks/task_e_68d3d7b2de68832bbc5e3c04931b3f9e