### PR TITLE
Normalize drag-drop authoring data and preload activity samples

### DIFF
--- a/assets/js/activities/flipCards.js
+++ b/assets/js/activities/flipCards.js
@@ -1,27 +1,53 @@
 import { clone, uid, escapeHtml } from '../utils.js';
 
+const createSampleCards = () => [
+  {
+    id: uid('card'),
+    front: 'Photosynthesis',
+    back: 'Plants convert sunlight, water, and CO₂ into glucose and oxygen.'
+  },
+  {
+    id: uid('card'),
+    front: 'Chlorophyll',
+    back: 'The green pigment that captures light energy for photosynthesis.'
+  },
+  {
+    id: uid('card'),
+    front: 'Light-dependent reactions',
+    back: 'Use sunlight to split water molecules and produce ATP and NADPH.'
+  },
+  {
+    id: uid('card'),
+    front: 'Calvin cycle',
+    back: 'Uses ATP and NADPH to fix carbon dioxide into sugars.'
+  }
+];
+
 const template = () => ({
-  cards: [
-    { id: uid('card'), front: 'Front', back: 'Back' }
-  ]
+  cards: createSampleCards()
 });
 
 const example = () => ({
   cards: [
     {
       id: uid('card'),
-      front: 'What is photosynthesis?',
-      back: 'A process used by plants to convert light energy into chemical energy.'
+      front: 'Photosynthesis overview',
+      back: 'Plants turn light, water, and CO₂ into glucose (food) and oxygen.'
     },
     {
       id: uid('card'),
-      front: 'Where does it occur?',
-      back: 'In the chloroplasts of plant cells.'
+      front: 'Where it happens',
+      back: 'Inside chloroplasts — mostly in the leaves of green plants.'
     },
     {
       id: uid('card'),
-      front: 'Key ingredients',
-      back: 'Carbon dioxide, water, and sunlight.'
+      front: 'Stage 1: Light reactions',
+      back: 'Chlorophyll captures sunlight to make energy carriers (ATP & NADPH).'
+    },
+    {
+      id: uid('card'),
+      front: 'Stage 2: Calvin cycle',
+      back: 'The plant uses ATP & NADPH to build sugars from carbon dioxide.'
     }
   ]
 });

--- a/assets/js/activities/hotspots.js
+++ b/assets/js/activities/hotspots.js
@@ -1,31 +1,42 @@
 import { clone, uid, escapeHtml } from '../utils.js';
 
+const createSampleHotspots = () => [
+  {
+    id: uid('hotspot'),
+    title: 'North America',
+    description: 'Home to diverse climates and ecosystems from the Arctic to the tropics.',
+    x: 25,
+    y: 35
+  },
+  {
+    id: uid('hotspot'),
+    title: 'Africa',
+    description: 'Known for the Sahara Desert and lush rainforests near the equator.',
+    x: 55,
+    y: 58
+  },
+  {
+    id: uid('hotspot'),
+    title: 'Australia',
+    description: 'An island continent featuring the Outback and the Great Barrier Reef.',
+    x: 78,
+    y: 75
+  }
+];
+
+const createSampleImage = () => ({
+  src: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAoAAAAHgCAYAAAB+7H0bAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAL+wAAC/sB4X8xJQAAABl0RVh0U29mdHdhcmUAZ2lmLm5ldCAyLjAuMTGsK74ZAAAI/klEQVR4nO3dQQ2DMBQEQfT+/2lHgx6UTKwxLBzME4f6HaW9rCaDz8ffP5/9wTzHAtBAAAAAAAAAPCVWdP2/Wv697P38eHL78v8zl+d/l+f37+ncF5rzuZ8l9PHGhYhfvbsRHxaYV+88VEcWmFevPFZHFpiXrxw3HNH2c9Z6/OZ8l1PGtjxh2l+W6PGHYX5bo8Ydhflujxh2F+W6PGHYX5bo8Ydhflujxh2F+W6PGHYX5bo8Ydhflujxh2F+W6PGHYX5bo8Ydhflujxh2F+W6PGHYX5bo8Ydhflujxh2F+W6PGHYX5bq8cv1+8Zz32j9O7P5nvM5X5/k+f37et7Xv78bfv+7j4h4tg0AAAAAAACAj40hA1Czbt0AAAAAAADgB+wBlcW3ya2F9DsAAAAASUVORK5CYII=',
+  alt: 'World map with highlighted continents'
+});
+
 const template = () => ({
-  image: null,
-  hotspots: []
+  image: createSampleImage(),
+  hotspots: createSampleHotspots()
 });
 
 const example = () => ({
-  image: {
-    src: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAoAAAAHgCAYAAAB+7H0bAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAL+wAAC/sB4X8xJQAAABl0RVh0U29mdHdhcmUAZ2lmLm5ldCAyLjAuMTGsK74ZAAAI/klEQVR4nO3dQQ2DMBQEQfT+/2lHgx6UTKwxLBzME4f6HaW9rCaDz8ffP5/9wTzHAtBAAAAAAAAAPCVWdP2/Wv697P38eHL78v8zl+d/l+f37+ncF5rzuZ8l9PHGhYhfvbsRHxaYV+88VEcWmFevPFZHFpiXrxw3HNH2c9Z6/OZ8l1PGtjxh2l+W6PGHYX5bo8Ydhflujxh2F+W6PGHYX5bo8Ydhflujxh2F+W6PGHYX5bo8Ydhflujxh2F+W6PGHYX5bo8Ydhflujxh2F+W6PGHYX5bo8Ydhflujxh2F+W6PGHYX5bo8Ydhflujxh2F+W6PGHYX5bq8cv1+8Zz32j9O7P5nvM5X5/k+f37et7Xv78bfv+7j4h4tg0AAAAAAACAj40hA1Czbt0AAAAAAADgB+wBlcW3ya2F9DsAAAAASUVORK5CYII=',
-    alt: 'World map with highlighted continents'
-  },
-  hotspots: [
-    {
-      id: uid('hotspot'),
-      title: 'North America',
-      description: 'Home to diverse climates and ecosystems from the Arctic to the tropics.',
-      x: 25,
-      y: 35
-    },
-    {
-      id: uid('hotspot'),
-      title: 'Africa',
-      description: 'Known for the Sahara Desert and lush rainforests near the equator.',
-      x: 55,
-      y: 58
-    }
-  ]
+  image: createSampleImage(),
+  hotspots: createSampleHotspots()
 });
 
 const buildEditor = (container, data, onUpdate) => {


### PR DESCRIPTION
## Summary
- add a normalizeAuthoringData helper to trim inputs and filter invalid bucket/item ids
- introduce reusable empty placeholder templates and export them for preview/embed use
- update preview and embed flows to short-circuit to the empty-state markup when authoring data is incomplete
- prepopulate flip card and hotspot templates with ready-to-edit sample content when authors switch activity types

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6562115d4832b888db327f7946c56