### PR TITLE
Fix activity builder compatibility without nullish operators

### DIFF
--- a/assets/js/activities/flipCards.js
+++ b/assets/js/activities/flipCards.js
@@ -156,7 +156,11 @@ const renderPreview = (container, data, { playAnimations }) => {
     const cardWrapper = document.createElement('div');
     cardWrapper.className = 'flipcard';
     const inner = document.createElement('div');
-    inner.className = `flipcard-inner ${playAnimations ? 'animate' : ''}`.trim();
+    inner.className = 'flipcard-inner';
+
+    if (playAnimations) {
+      inner.classList.add('animate');
+    }
 
     const front = document.createElement('div');
     front.className = 'flipcard-face flipcard-front';
@@ -173,20 +177,36 @@ const renderPreview = (container, data, { playAnimations }) => {
     inner.append(front, back);
     cardWrapper.append(inner);
 
-    cardWrapper.addEventListener('click', () => {
-      const flipped = cardWrapper.classList.toggle('flipped');
-      cardWrapper.setAttribute('aria-pressed', String(flipped));
-    });
+    const setFlipState = (flipped) => {
+      if (flipped) {
+        cardWrapper.classList.add('flipped');
+        if (playAnimations) {
+          inner.classList.remove('animate');
+        }
+      } else {
+        cardWrapper.classList.remove('flipped');
+        if (playAnimations) {
+          inner.classList.add('animate');
+        }
+      }
+      cardWrapper.setAttribute('aria-pressed', flipped ? 'true' : 'false');
+    };
+
+    const toggleFlip = () => {
+      const nextState = !cardWrapper.classList.contains('flipped');
+      setFlipState(nextState);
+    };
+
+    cardWrapper.addEventListener('click', toggleFlip);
     cardWrapper.addEventListener('keypress', (event) => {
       if (event.key === 'Enter' || event.key === ' ') {
         event.preventDefault();
-        const flipped = cardWrapper.classList.toggle('flipped');
-        cardWrapper.setAttribute('aria-pressed', String(flipped));
+        toggleFlip();
       }
     });
     cardWrapper.setAttribute('tabindex', '0');
     cardWrapper.setAttribute('role', 'button');
-    cardWrapper.setAttribute('aria-pressed', 'false');
+    setFlipState(false);
 
     grid.append(cardWrapper);
   });

--- a/assets/js/activities/hotspots.js
+++ b/assets/js/activities/hotspots.js
@@ -41,7 +41,11 @@ const example = () => ({
 
 const buildEditor = (container, data, onUpdate) => {
   const working = clone(data);
-  let activeId = working.hotspots[0]?.id ?? null;
+  if (!Array.isArray(working.hotspots)) {
+    working.hotspots = [];
+  }
+  const firstHotspot = working.hotspots.length > 0 ? working.hotspots[0] : null;
+  let activeId = firstHotspot ? firstHotspot.id : null;
 
   const emit = (refresh = true) => {
     onUpdate(clone(working));
@@ -52,9 +56,13 @@ const buildEditor = (container, data, onUpdate) => {
     if (!file) return;
     const reader = new FileReader();
     reader.onload = () => {
+      const existingAlt = working.image && typeof working.image.alt === 'string' ? working.image.alt : '';
+      const defaultAlt = file
+        ? file.name.replace(/\.[^.]+$/, '').replace(/[-_]/g, ' ')
+        : '';
       working.image = {
         src: reader.result,
-        alt: working.image?.alt || file.name.replace(/\.[^.]+$/, '').replace(/[-_]/g, ' ')
+        alt: existingAlt || defaultAlt
       };
       emit();
     };
@@ -202,7 +210,10 @@ const buildEditor = (container, data, onUpdate) => {
       deleteBtn.addEventListener('click', () => {
         const idx = working.hotspots.findIndex((s) => s.id === spot.id);
         if (idx >= 0) working.hotspots.splice(idx, 1);
-        if (activeId === spot.id) activeId = working.hotspots[0]?.id ?? null;
+        if (activeId === spot.id) {
+          const nextHotspot = working.hotspots.length > 0 ? working.hotspots[0] : null;
+          activeId = nextHotspot ? nextHotspot.id : null;
+        }
         emit();
       });
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -49,7 +49,10 @@ const showStatus = (message, tone = 'info') => {
   elements.statusToast.dataset.tone = tone;
   elements.statusToast.classList.add('visible');
   setTimeout(() => {
-    elements.statusToast?.classList.remove('visible');
+    const toast = elements.statusToast;
+    if (toast) {
+      toast.classList.remove('visible');
+    }
   }, 2600);
 };
 
@@ -82,7 +85,7 @@ const refreshPreview = () => {
   const activity = getActiveActivity();
   if (!activity) return;
   activity.renderPreview(elements.previewArea, state.data, {
-    playAnimations: elements.animationToggle?.checked
+    playAnimations: elements.animationToggle ? elements.animationToggle.checked : false
   });
 };
 
@@ -199,7 +202,7 @@ const handleSaveProject = async () => {
   }
 
   const project = {
-    id: state.id ?? uid('project'),
+    id: state.id === null || state.id === undefined ? uid('project') : state.id,
     title: state.title.trim(),
     description: state.description.trim(),
     type: state.type,

--- a/assets/js/storage.js
+++ b/assets/js/storage.js
@@ -6,7 +6,7 @@ import {
   getDocs,
   setDoc
 } from 'https://www.gstatic.com/firebasejs/10.8.0/firebase-firestore.js';
-import { clone } from './utils.js';
+import { clone, coalesce } from './utils.js';
 import { getFirestoreDb } from './firebaseClient.js';
 
 const COLLECTION_NAME = 'canvasDesignerActivities';
@@ -17,11 +17,11 @@ const mapSnapshotToProject = (snapshot) => {
   if (!data) return null;
   return {
     id: snapshot.id,
-    title: data.title ?? '',
-    description: data.description ?? '',
-    type: data.type ?? '',
-    data: data.data ?? {},
-    updatedAt: data.updatedAt ?? null
+    title: coalesce(data.title, ''),
+    description: coalesce(data.description, ''),
+    type: coalesce(data.type, ''),
+    data: coalesce(data.data, {}),
+    updatedAt: coalesce(data.updatedAt, null)
   };
 };
 
@@ -49,10 +49,10 @@ export const saveProject = async (project) => {
   value.id = documentId;
   const docRef = doc(collectionRef, documentId);
   const payload = {
-    title: value.title ?? '',
-    description: value.description ?? '',
-    type: value.type ?? '',
-    data: value.data ?? {},
+    title: coalesce(value.title, ''),
+    description: coalesce(value.description, ''),
+    type: coalesce(value.type, ''),
+    data: coalesce(value.data, {}),
     updatedAt
   };
 
@@ -75,5 +75,5 @@ export const getProject = async (projectId) => {
     return null;
   }
   const project = mapSnapshotToProject(snapshot);
-  return project ? { ...project, data: project.data ?? {} } : null;
+  return project ? { ...project, data: coalesce(project.data, {}) } : null;
 };

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -3,8 +3,10 @@ export const clone = (value) => JSON.parse(JSON.stringify(value));
 let uidCounter = 0;
 export const uid = (prefix = 'item') => `${prefix}-${Date.now().toString(36)}-${uidCounter++}`;
 
+export const coalesce = (value, fallback) => (value === null || value === undefined ? fallback : value);
+
 export const escapeHtml = (value) =>
-  String(value ?? '')
+  String(coalesce(value, ''))
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')


### PR DESCRIPTION
## Summary
- replace usages of optional chaining and nullish coalescing in the authoring app with defensive checks so the script loads in legacy browsers
- add a reusable coalesce helper and update storage utilities and activity modules to use it when normalising data
- ensure drag & drop and hotspots editors gracefully recover default selections without modern language features
- restore flip card previews so clicking toggles the card even when animations are enabled

## Testing
- python3 -m http.server 4173

------
https://chatgpt.com/codex/tasks/task_e_68d662795958832bb3d65d1e49a23e36