### PR TITLE
Fix activity builder compatibility and refresh embed UI

### DIFF
--- a/assets/js/activities/hotspots.js
+++ b/assets/js/activities/hotspots.js
@@ -41,7 +41,11 @@ const example = () => ({
 
 const buildEditor = (container, data, onUpdate) => {
   const working = clone(data);
-  let activeId = working.hotspots[0]?.id ?? null;
+  if (!Array.isArray(working.hotspots)) {
+    working.hotspots = [];
+  }
+  const firstHotspot = working.hotspots.length > 0 ? working.hotspots[0] : null;
+  let activeId = firstHotspot ? firstHotspot.id : null;
 
   const emit = (refresh = true) => {
     onUpdate(clone(working));
@@ -52,9 +56,13 @@ const buildEditor = (container, data, onUpdate) => {
     if (!file) return;
     const reader = new FileReader();
     reader.onload = () => {
+      const existingAlt = working.image && typeof working.image.alt === 'string' ? working.image.alt : '';
+      const defaultAlt = file
+        ? file.name.replace(/\.[^.]+$/, '').replace(/[-_]/g, ' ')
+        : '';
       working.image = {
         src: reader.result,
-        alt: working.image?.alt || file.name.replace(/\.[^.]+$/, '').replace(/[-_]/g, ' ')
+        alt: existingAlt || defaultAlt
       };
       emit();
     };
@@ -202,7 +210,10 @@ const buildEditor = (container, data, onUpdate) => {
       deleteBtn.addEventListener('click', () => {
         const idx = working.hotspots.findIndex((s) => s.id === spot.id);
         if (idx >= 0) working.hotspots.splice(idx, 1);
-        if (activeId === spot.id) activeId = working.hotspots[0]?.id ?? null;
+        if (activeId === spot.id) {
+          const nextHotspot = working.hotspots.length > 0 ? working.hotspots[0] : null;
+          activeId = nextHotspot ? nextHotspot.id : null;
+        }
         emit();
       });
 

--- a/assets/js/storage.js
+++ b/assets/js/storage.js
@@ -6,7 +6,7 @@ import {
   getDocs,
   setDoc
 } from 'https://www.gstatic.com/firebasejs/10.8.0/firebase-firestore.js';
-import { clone } from './utils.js';
+import { clone, coalesce } from './utils.js';
 import { getFirestoreDb } from './firebaseClient.js';
 
 const COLLECTION_NAME = 'canvasDesignerActivities';
@@ -17,11 +17,11 @@ const mapSnapshotToProject = (snapshot) => {
   if (!data) return null;
   return {
     id: snapshot.id,
-    title: data.title ?? '',
-    description: data.description ?? '',
-    type: data.type ?? '',
-    data: data.data ?? {},
-    updatedAt: data.updatedAt ?? null
+    title: coalesce(data.title, ''),
+    description: coalesce(data.description, ''),
+    type: coalesce(data.type, ''),
+    data: coalesce(data.data, {}),
+    updatedAt: coalesce(data.updatedAt, null)
   };
 };
 
@@ -49,10 +49,10 @@ export const saveProject = async (project) => {
   value.id = documentId;
   const docRef = doc(collectionRef, documentId);
   const payload = {
-    title: value.title ?? '',
-    description: value.description ?? '',
-    type: value.type ?? '',
-    data: value.data ?? {},
+    title: coalesce(value.title, ''),
+    description: coalesce(value.description, ''),
+    type: coalesce(value.type, ''),
+    data: coalesce(value.data, {}),
     updatedAt
   };
 
@@ -75,5 +75,5 @@ export const getProject = async (projectId) => {
     return null;
   }
   const project = mapSnapshotToProject(snapshot);
-  return project ? { ...project, data: project.data ?? {} } : null;
+  return project ? { ...project, data: coalesce(project.data, {}) } : null;
 };

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -3,8 +3,10 @@ export const clone = (value) => JSON.parse(JSON.stringify(value));
 let uidCounter = 0;
 export const uid = (prefix = 'item') => `${prefix}-${Date.now().toString(36)}-${uidCounter++}`;
 
+export const coalesce = (value, fallback) => (value === null || value === undefined ? fallback : value);
+
 export const escapeHtml = (value) =>
-  String(value ?? '')
+  String(coalesce(value, ''))
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -75,7 +75,6 @@ body::before {
   background: var(--surface);
   border-radius: 28px;
   box-shadow: var(--shadow-lg);
-  overflow: hidden;
   backdrop-filter: blur(40px);
   border: 1px solid rgba(255, 255, 255, 0.65);
 }
@@ -152,6 +151,36 @@ body::before {
   flex-direction: column;
   gap: 16px;
   border: 1px solid rgba(15, 23, 42, 0.04);
+}
+
+.embed-panel {
+  transition: max-height 260ms ease, opacity 160ms ease, padding 200ms ease;
+  max-height: 0;
+  opacity: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+  pointer-events: none;
+  gap: 12px;
+  border: 0;
+  overflow: hidden;
+  box-shadow: none;
+}
+
+.embed-panel[data-open='true'] {
+  max-height: 480px;
+  opacity: 1;
+  padding-top: 20px;
+  padding-bottom: 20px;
+  pointer-events: auto;
+  border: 1px solid rgba(15, 23, 42, 0.04);
+  box-shadow: 0 18px 40px rgba(15, 23, 42, 0.08);
+}
+
+.embed-panel-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
 }
 
 .panel-title {
@@ -369,6 +398,11 @@ textarea:focus {
 .flipcard {
   perspective: 1000px;
   cursor: pointer;
+  position: relative;
+  opacity: 0;
+  transform: translateY(18px) scale(0.98);
+  animation: flipcard-reveal 420ms cubic-bezier(0.22, 0.61, 0.36, 1) forwards;
+  animation-delay: calc(var(--card-index, 0) * 120ms);
 }
 
 .flipcard-inner {
@@ -393,6 +427,17 @@ textarea:focus {
   }
 }
 
+@keyframes flipcard-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(18px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
 .flipcard:focus-visible .flipcard-inner,
 .flipcard:hover .flipcard-inner {
   box-shadow: 0 16px 32px rgba(99, 102, 241, 0.22);
@@ -414,6 +459,23 @@ textarea:focus {
   text-align: center;
   font-size: 1.05rem;
   box-shadow: 0 18px 36px rgba(15, 23, 42, 0.16);
+  overflow: hidden;
+}
+
+.flipcard-face::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.35), transparent 55%);
+  opacity: 0;
+  transform: translateY(12%);
+  transition: opacity 200ms ease, transform 260ms ease;
+}
+
+.flipcard:hover .flipcard-face::after,
+.flipcard:focus-visible .flipcard-face::after {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 .flipcard-front {
@@ -724,41 +786,6 @@ textarea:focus {
     opacity: 1;
     transform: translateY(0) scale(1);
   }
-}
-
-.dialog-card {
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-direction: column;
-  gap: 16px;
-  width: min(720px, 90vw);
-  background: var(--surface-strong);
-  border-radius: 24px;
-  border: 1px solid rgba(15, 23, 42, 0.08);
-  box-shadow: 0 40px 80px rgba(15, 23, 42, 0.3);
-  padding: 28px;
-}
-
-.dialog-header h2 {
-  margin: 0 0 6px;
-}
-
-.dialog-code {
-  height: 320px;
-  resize: vertical;
-  font-family: 'SFMono-Regular', 'Consolas', 'Liberation Mono', 'Menlo', monospace;
-  background: rgba(15, 23, 42, 0.92);
-  color: #f8fafc;
-  padding: 18px;
-  border-radius: var(--radius-xs);
-  border: 1px solid rgba(15, 23, 42, 0.6);
-}
-
-.dialog-actions {
-  display: flex;
-  justify-content: flex-end;
-  gap: 12px;
 }
 
 @media (max-width: 1140px) {

--- a/index.html
+++ b/index.html
@@ -22,7 +22,15 @@
         </div>
         <div class="header-actions">
           <button id="newProjectBtn" class="ghost-button" type="button">New activity</button>
-          <button id="showEmbedBtn" class="primary-button" type="button">Embed code</button>
+          <button
+            id="showEmbedBtn"
+            class="primary-button"
+            type="button"
+            aria-controls="embedPanel"
+            aria-expanded="false"
+          >
+            Embed code
+          </button>
         </div>
       </header>
       <div id="statusToast" class="status-toast" role="status" aria-live="polite"></div>
@@ -68,9 +76,19 @@
             </div>
             <div id="editorContent" class="editor-content" aria-live="polite"></div>
           </section>
-          <section class="panel-block">
-            <h2 class="panel-title">Embed code for Canvas</h2>
-            <p class="hint">Canvas supports the <code>&lt;iframe&gt;</code> element. Use the code below or click "Embed code" to open a larger view.</p>
+          <section
+            id="embedPanel"
+            class="panel-block embed-panel"
+            data-open="false"
+            aria-hidden="true"
+          >
+            <div class="embed-panel-header">
+              <div>
+                <h2 class="panel-title">Embed code for Canvas</h2>
+                <p class="hint">Copy this HTML into Canvas using the rich content editor's HTML mode.</p>
+              </div>
+              <button id="hideEmbedBtn" class="ghost-button" type="button" aria-label="Hide embed code">Hide</button>
+            </div>
             <textarea id="embedSnippet" class="code-preview" rows="7" readonly></textarea>
             <div class="panel-actions">
               <button id="copyEmbedInlineBtn" class="ghost-button" type="button">Copy</button>
@@ -98,20 +116,6 @@
         </section>
       </main>
     </div>
-
-    <dialog id="embedDialog">
-      <form method="dialog" class="dialog-card">
-        <header class="dialog-header">
-          <h2>Canvas embed code</h2>
-          <p class="hint">Copy and paste this HTML into the Canvas LMS rich content editor using the HTML view.</p>
-        </header>
-        <textarea id="embedOutput" class="dialog-code" rows="16" readonly></textarea>
-        <footer class="dialog-actions">
-          <button class="ghost-button" value="cancel" type="submit">Close</button>
-          <button id="dialogCopyBtn" class="primary-button" type="button">Copy code</button>
-        </footer>
-      </form>
-    </dialog>
 
     <template id="hotspot-marker-template">
       <div class="hotspot-marker" role="button" tabindex="0">


### PR DESCRIPTION
## Summary
- replace usages of optional chaining and nullish coalescing in the authoring app with defensive checks so the script loads in legacy browsers
- add a reusable coalesce helper and update storage utilities and activity modules to use it when normalising data
- ensure drag & drop and hotspots editors gracefully recover default selections without modern language features
- restore flip card previews so clicking toggles the card even when animations are enabled
- add animated flip card reveals and hover lighting while respecting the animation toggle and embed output
- surface the Canvas embed code from a header button that expands a focused panel, fixing the layout overflow so the controls remain accessible

## Testing
- python3 -m http.server 4173

------
https://chatgpt.com/codex/tasks/task_e_68d662795958832bb3d65d1e49a23e36