### PR TITLE
Secure Firestore writes via shared service password

### DIFF
--- a/docs/firebase-setup.md
+++ b/docs/firebase-setup.md
@@ -1,0 +1,39 @@
+# Firebase configuration for Canvas Designer
+
+Follow these steps to secure Firestore access with a shared service password and allow the web app to save activities automatically.
+
+## 1. Enable Email/Password authentication
+1. Open the [Firebase console](https://console.firebase.google.com/).
+2. Select the **tdt-sandbox** project (or the project you deploy to).
+3. Go to **Build → Authentication → Sign-in method**.
+4. Enable **Email/Password** sign-in and click **Save**.
+
+## 2. Create the service account user
+1. Still under **Authentication**, switch to the **Users** tab.
+2. Click **Add user**.
+3. Enter the following credentials:
+   - **Email**: `canvasdesigner-service@tdt-sandbox.firebaseapp.com`
+   - **Password**: `saltisasin`
+4. Click **Add user** to create the hidden service account.
+
+> Only the app needs this password. End users never see a login prompt because the app signs in silently with the stored credentials.
+
+## 3. Deploy the Firestore rules
+1. Install the Firebase CLI if you have not already: `npm install -g firebase-tools`.
+2. Authenticate the CLI: `firebase login`.
+3. In your local project directory, deploy the included rules file: `firebase deploy --only firestore:rules`.
+
+The `firestore.rules` file restricts document writes in the `canvasDesignerActivities` collection to the service user email while keeping reads public.
+
+## 4. Optional: rotate the shared password later
+- Generate a strong password in the Firebase console and update the base64-encoded string in `assets/js/firebaseClient.js`.
+- To encode a new password locally, run `node -e "console.log(Buffer.from('<new-password>', 'utf8').toString('base64'))"` and replace the encoded value in the code.
+- After updating the code, redeploy the site so the new password takes effect.
+
+## 5. Embedding in Canvas
+1. In the app, build your activity and open the **Embed code** panel.
+2. Click **Copy** to copy the generated snippet.
+3. In Canvas, edit the page in **HTML Editor** mode (not the Rich Content Editor).
+4. Paste the snippet and save. Canvas may show a blank editor preview, but the activity will render when the page is viewed.
+5. If Canvas removes scripts on save, ensure you are using the full HTML editor or the "Insert → Embed" option. The snippet is self-contained and does not load external scripts.
+

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,9 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    match /canvasDesignerActivities/{documentId} {
+      allow read: if true;
+      allow write: if request.auth != null && request.auth.token.email == 'canvasdesigner-service@tdt-sandbox.firebaseapp.com';
+    }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Interactive Activity Designer 2</title>
+    <title>Interactive Activity Designer</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -17,7 +17,7 @@
     <div id="app" class="app-shell">
       <header class="app-header">
         <div class="brand">
-          <span class="logo">Interactive Activity Designer 2</span>
+            <span class="logo">Interactive Activity Designer</span>
           <p class="tagline">Create, save, and share engaging Canvas learning activities.</p>
         </div>
         <div class="header-actions">


### PR DESCRIPTION
## Summary
- replace anonymous Firebase auth with a hidden email/password service user so saves succeed behind a shared secret
- add Firestore security rules and documentation that walks through enabling auth, creating the service user, and deploying the rules
- update the HTML document title to remove the trailing “2”

## Testing
- not run (documentation and config changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d671b96924832ba46f4e76913ee28d