### PR TITLE
Add hosted embed viewer and iframe embed snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Canvas Designer Studio is a modern single-page web app for crafting interactive 
 - 🎯 **Activity builder** – Guided authoring panels for flip cards, drag & drop matchers, and hotspot explorations.
 - ✨ **Live preview** – Interactions update in real time with accessible controls and animation toggles.
 - ☁️ **Cloud saving** – Store and retrieve activities securely in Firebase so they follow you across devices.
-- 🔗 **Canvas-ready embed code** – Generates a self-contained HTML/CSS/JS snippet suitable for Canvas LMS (or any LMS that accepts iframe/HTML embeds).
+- 🔗 **Canvas-ready embed code** – Generates an iframe snippet that loads a hosted viewer suitable for Canvas LMS (or any LMS that accepts iframe embeds).
 - 🖼️ **Image hotspots** – Upload a custom image, place hotspots visually, and describe each point of interest.
 - 🌈 **Polished UI** – Responsive layout, rich styling, and subtle animations for an inspiring authoring experience.
 
@@ -19,7 +19,7 @@ Canvas Designer Studio is a modern single-page web app for crafting interactive 
 4. Preview the interaction on the right. Use the toggle to pause or resume entrance animations.
 5. Copy the generated embed snippet from the **Embed code** section or open the dialog for a full-screen view. Paste the snippet into the Canvas LMS HTML editor.
 
-> **Tip:** Canvas strips external scripts in the rich content editor. The generated embed code is completely self-contained, so it will keep working when pasted into Canvas pages, assignments, or modules.
+> **Tip:** Canvas strips external scripts in the rich content editor. The generated snippet now uses an iframe that points to the GitHub Pages viewer, so it keeps working even after Canvas sanitizes the HTML.
 
 ## Project structure
 
@@ -31,6 +31,7 @@ assets/
   js/
     app.js            # Application bootstrap and state management
     embed.js          # Canvas embed code generator
+    embedViewer.js    # Lightweight runtime for the hosted viewer
     storage.js        # Firebase persistence helpers
     utils.js          # Shared helpers
     activities/
@@ -38,13 +39,16 @@ assets/
       flipCards.js    # Flip card editor + renderer
       dragDrop.js     # Drag & drop editor + renderer
       hotspots.js     # Hotspot editor + renderer
+docs/
+  embed.html          # Read-only viewer published to GitHub Pages
 ```
 
 ## Development notes
 
 - The app uses vanilla JavaScript modules (`type="module"`) so it can run from the filesystem without a build step.
 - Activity editors encapsulate their own input rendering logic to avoid conflicts during concurrent development.
-- Embed snippets scope their CSS and JavaScript by unique IDs so multiple embeds can coexist on the same Canvas page.
+- Embed snippets now render via a sandboxed iframe hitting `https://galvinradleyngo.github.io/canvasdesigner/embed.html`, keeping Canvas-compatible markup while isolating scripts and styles.
+- The hosted viewer validates the payload version, activity type, and text fields before rendering to guard against tampered URLs.
 
 ## Browser support
 

--- a/assets/js/embedViewer.js
+++ b/assets/js/embedViewer.js
@@ -1,0 +1,166 @@
+import { activities } from './activities/index.js';
+
+const VIEW_ROOT_ID = 'cd-embed-viewer-root';
+
+const baseStyles = (containerId) => `
+  #${containerId} {
+    font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    color: #0f172a;
+    line-height: 1.5;
+    display: grid;
+    gap: 1rem;
+  }
+  #${containerId} *,
+  #${containerId} *::before,
+  #${containerId} *::after {
+    box-sizing: border-box;
+  }
+  #${containerId} .cd-embed-title {
+    font-size: 1.25rem;
+    font-weight: 600;
+    margin: 0;
+  }
+  #${containerId} .cd-embed-description {
+    margin: 0;
+    color: rgba(15, 23, 42, 0.7);
+  }
+`;
+
+const sanitizeText = (value, { maxLength = 1200 } = {}) => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  const trimmed = value.trim();
+  return trimmed.length > maxLength ? trimmed.slice(0, maxLength) : trimmed;
+};
+
+const decodeBase64Url = (value) => {
+  const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = normalized.padEnd(Math.ceil(normalized.length / 4) * 4, '=');
+  const binary = atob(padded);
+
+  if (typeof TextDecoder !== 'undefined') {
+    const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+    return new TextDecoder().decode(bytes);
+  }
+
+  let escaped = '';
+  for (let index = 0; index < binary.length; index += 1) {
+    const code = binary.charCodeAt(index);
+    escaped += `%${(`00${code.toString(16)}`).slice(-2)}`;
+  }
+  return decodeURIComponent(escaped);
+};
+
+const parsePayload = () => {
+  const params = new URLSearchParams(window.location.search);
+  let raw = params.get('data');
+  if (!raw && window.location.hash.length > 1) {
+    raw = window.location.hash.slice(1);
+  }
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const text = decodeBase64Url(raw);
+    const payload = JSON.parse(text);
+    if (!payload || typeof payload !== 'object') {
+      return null;
+    }
+    return payload;
+  } catch (error) {
+    console.warn('Unable to parse embed payload', error);
+    return null;
+  }
+};
+
+const showMessage = (root, message) => {
+  root.innerHTML = '';
+  const notice = document.createElement('div');
+  notice.className = 'cd-viewer-message';
+  notice.setAttribute('role', 'alert');
+  notice.textContent = message;
+  root.append(notice);
+};
+
+const renderActivity = (root, payload) => {
+  const type = typeof payload.type === 'string' ? payload.type.trim() : '';
+  const activity = activities[type];
+
+  if (!activity) {
+    showMessage(root, 'This activity type is not supported.');
+    return;
+  }
+
+  const content = payload.content && typeof payload.content === 'object' ? payload.content : {};
+  const containerId = `cd-activity-${Date.now().toString(36)}`;
+  const parts = activity.embedTemplate(content, containerId);
+
+  const fragment = document.createDocumentFragment();
+
+  const title = sanitizeText(payload.title, { maxLength: 200 });
+  if (title) {
+    const heading = document.createElement('h1');
+    heading.className = 'cd-embed-title';
+    heading.textContent = title;
+    fragment.append(heading);
+    document.title = `${title} • Canvas Designer Viewer`;
+  }
+
+  const description = sanitizeText(payload.description);
+  if (description) {
+    const desc = document.createElement('p');
+    desc.className = 'cd-embed-description';
+    desc.textContent = description;
+    fragment.append(desc);
+  }
+
+  const container = document.createElement('div');
+  container.id = containerId;
+  container.className = `cd-embed cd-embed-${type}`;
+  container.dataset.activity = type;
+  container.innerHTML = parts.html;
+  fragment.append(container);
+
+  root.innerHTML = '';
+  root.append(fragment);
+
+  const style = document.createElement('style');
+  style.textContent = `${baseStyles(containerId)}\n${parts.css}`;
+  document.head.append(style);
+
+  if (parts.js) {
+    const script = document.createElement('script');
+    script.textContent = parts.js;
+    document.body.append(script);
+  }
+};
+
+const bootstrap = () => {
+  const root = document.getElementById(VIEW_ROOT_ID);
+  if (!root) {
+    console.warn('Viewer root element missing');
+    return;
+  }
+
+  const payload = parsePayload();
+  if (!payload) {
+    showMessage(root, 'No activity data provided.');
+    return;
+  }
+
+  const version = typeof payload.v === 'number' ? payload.v : 0;
+  if (version !== 1) {
+    showMessage(root, 'This activity was created with an incompatible version.');
+    return;
+  }
+
+  renderActivity(root, payload);
+};
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', bootstrap);
+} else {
+  bootstrap();
+}

--- a/docs/embed.html
+++ b/docs/embed.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Canvas Designer Viewer</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <style>
+      :root {
+        color-scheme: light;
+      }
+      *,
+      *::before,
+      *::after {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        background: #f8fafc;
+        color: #0f172a;
+        display: flex;
+        justify-content: center;
+        padding: 2.5rem 1.5rem;
+      }
+      .cd-embed-viewer-shell {
+        width: min(960px, 100%);
+        background: #ffffff;
+        border-radius: 20px;
+        padding: clamp(1.5rem, 2vw + 1rem, 2.5rem);
+        box-shadow: 0 24px 48px rgba(15, 23, 42, 0.12);
+      }
+      .cd-viewer-message {
+        padding: 1.25rem;
+        border-radius: 12px;
+        background: rgba(59, 130, 246, 0.1);
+        color: #1d4ed8;
+        font-weight: 500;
+        text-align: center;
+      }
+    </style>
+  </head>
+  <body>
+    <main class="cd-embed-viewer-shell">
+      <div id="cd-embed-viewer-root" aria-live="polite"></div>
+    </main>
+    <script type="module" src="../assets/js/embedViewer.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a read-only viewer page under docs and its supporting script for rendering activities safely
- update the embed generator to serialize activity data and point to the hosted viewer iframe
- document the new embedding workflow and hosted viewer behaviour

## Testing
- not run (static site change)


------
https://chatgpt.com/codex/tasks/task_e_68d67e88d808832ba5e067b7c381665e