### PR TITLE
Keep preview visible and sync flip card colors

### DIFF
--- a/assets/js/activities/flipCards.js
+++ b/assets/js/activities/flipCards.js
@@ -84,7 +84,8 @@ const createSampleCards = () =>
 
 const template = () => ({
   columns: 3,
-  cards: createSampleCards()
+  cards: createSampleCards(),
+  matchFirstColor: false
 });
 
 const example = () => ({
@@ -106,14 +107,16 @@ const example = () => ({
       front: 'Stage 2: Calvin cycle',
       back: 'The plant uses ATP & NADPH to build sugars from carbon dioxide.'
     }
-  ])
+  ]),
+  matchFirstColor: false
 });
 
 const ensureWorkingState = (data) => {
   const safeData = data ? clone(data) : {};
   return {
     columns: clampColumns(safeData.columns),
-    cards: normaliseCards(safeData.cards)
+    cards: normaliseCards(safeData.cards),
+    matchFirstColor: Boolean(safeData.matchFirstColor)
   };
 };
 
@@ -132,7 +135,19 @@ const readFileAsDataUrl = (file) =>
 const buildEditor = (container, data, onUpdate) => {
   const working = ensureWorkingState(data);
 
+  const applySyncedColors = () => {
+    if (!working.matchFirstColor || working.cards.length <= 1) {
+      return;
+    }
+    const source = working.cards[0];
+    for (let i = 1; i < working.cards.length; i += 1) {
+      working.cards[i].frontColor = source.frontColor;
+      working.cards[i].backColor = source.backColor;
+    }
+  };
+
   const emit = (refresh = true) => {
+    applySyncedColors();
     onUpdate(clone(working));
     if (refresh) {
       rerender();
@@ -140,6 +155,7 @@ const buildEditor = (container, data, onUpdate) => {
   };
 
   const rerender = () => {
+    applySyncedColors();
     container.innerHTML = '';
 
     const layoutItem = document.createElement('div');
@@ -270,6 +286,16 @@ const buildEditor = (container, data, onUpdate) => {
         });
         colorField.append(colorInput);
 
+        const locked = working.matchFirstColor && index !== 0;
+        if (locked) {
+          colorInput.disabled = true;
+          colorField.classList.add('card-color-field--locked');
+          const lockHint = document.createElement('span');
+          lockHint.className = 'hint';
+          lockHint.textContent = 'Colors follow Card 1 while sync is on.';
+          colorField.append(lockHint);
+        }
+
         const imageField = document.createElement('div');
         imageField.className = 'field card-image-field';
         const imageLabel = document.createElement('span');
@@ -350,6 +376,33 @@ const buildEditor = (container, data, onUpdate) => {
       );
 
       item.append(header, frontLabel, backLabel, appearanceRow);
+
+      if (index === 0) {
+        const syncToggle = document.createElement('label');
+        syncToggle.className = 'card-sync-toggle';
+        const syncCheckbox = document.createElement('input');
+        syncCheckbox.type = 'checkbox';
+        syncCheckbox.checked = Boolean(working.matchFirstColor);
+        const syncText = document.createElement('div');
+        syncText.className = 'card-sync-text';
+        const syncTitle = document.createElement('span');
+        syncTitle.className = 'card-sync-title';
+        syncTitle.textContent = 'Use this color for all cards';
+        const syncHint = document.createElement('span');
+        syncHint.className = 'hint';
+        syncHint.textContent = 'Other cards inherit front and back colors from Card 1.';
+        syncText.append(syncTitle, syncHint);
+        syncToggle.append(syncCheckbox, syncText);
+        syncCheckbox.addEventListener('change', () => {
+          working.matchFirstColor = syncCheckbox.checked;
+          if (syncCheckbox.checked) {
+            applySyncedColors();
+          }
+          emit();
+        });
+        item.append(syncToggle);
+      }
+
       container.append(item);
     });
 
@@ -367,14 +420,22 @@ const renderPreview = (container, data, options = {}) => {
     const empty = document.createElement('div');
     empty.className = 'empty-state';
     empty.innerHTML = '<p>Add cards to see a live preview.</p>';
-    container.append(empty);https://github.com/galvinradleyngo/canvasdesigner/pull/19/conflict?name=assets%252Fjs%252Factivities%252FflipCards.js&ancestor_oid=ffc6d3109be2aa873f3e15d84f88273f7022824f&base_oid=94743a8a927078736600e5f57b55d523b6f40c13&head_oid=394b7a520d6cffa994f5ba87105526248d823524
+    container.append(empty);
     return;
   }
+  const useSyncedColors = working.matchFirstColor && working.cards.length > 0;
+  const cardsForPreview = useSyncedColors
+    ? working.cards.map((card, index) =>
+        index === 0
+          ? card
+          : { ...card, frontColor: working.cards[0].frontColor, backColor: working.cards[0].backColor }
+      )
+    : working.cards;
   const grid = document.createElement('div');
   grid.className = 'flipcard-grid';
   grid.style.gridTemplateColumns = `repeat(${working.columns}, minmax(0, 1fr))`;
 
-  working.cards.forEach((card, index) => {
+  cardsForPreview.forEach((card, index) => {
     const cardWrapper = document.createElement('div');
     cardWrapper.className = 'flipcard';
     cardWrapper.style.setProperty('--card-index', String(index));
@@ -388,8 +449,13 @@ const renderPreview = (container, data, options = {}) => {
     const createFace = (faceKey, fallbackText) => {
       const face = document.createElement('div');
       face.className = `flipcard-face flipcard-${faceKey}`;
-      const color = card[`${faceKey}Color`];
-      face.style.background = color || (faceKey === 'front' ? DEFAULT_FRONT_COLORS[index % DEFAULT_FRONT_COLORS.length] : DEFAULT_BACK_COLOR);
+      const fallbackIndex = useSyncedColors ? 0 : index;
+      const fallbackColor =
+        faceKey === 'front'
+          ? DEFAULT_FRONT_COLORS[fallbackIndex % DEFAULT_FRONT_COLORS.length]
+          : DEFAULT_BACK_COLOR;
+      const color = card[`${faceKey}Color`] || fallbackColor;
+      face.style.background = color;
       const imageValue = card[`${faceKey}Image`];
       if (imageValue) {
         face.classList.add('has-image');
@@ -454,16 +520,24 @@ const renderPreview = (container, data, options = {}) => {
 const embedTemplate = (data, containerId) => {
   const working = ensureWorkingState(data);
   const columns = working.columns;
+  const useSyncedColors = working.matchFirstColor && working.cards.length > 0;
+  const cardsForEmbed = useSyncedColors
+    ? working.cards.map((card, index) =>
+        index === 0
+          ? card
+          : { ...card, frontColor: working.cards[0].frontColor, backColor: working.cards[0].backColor }
+      )
+    : working.cards;
   return {
     html: `
     <div class="cd-flipcard-grid" style="grid-template-columns: repeat(${columns}, minmax(0, 1fr));">
-      ${working.cards
+      ${cardsForEmbed
         .map(
           (card, index) => `
           <div class="cd-flipcard" tabindex="0" role="button" aria-pressed="false" style="--card-index: ${index};">
             <div class="cd-flipcard-inner animate">
               <div class="cd-flipcard-face cd-flipcard-front${card.frontImage ? ' has-image' : ''}" style="background: ${escapeHtml(
-                card.frontColor || DEFAULT_FRONT_COLORS[index % DEFAULT_FRONT_COLORS.length]
+                card.frontColor || DEFAULT_FRONT_COLORS[(useSyncedColors ? 0 : index) % DEFAULT_FRONT_COLORS.length]
               )};">
                 ${card.frontImage ? `<img src="${escapeHtml(card.frontImage)}" alt="" />` : ''}
                 <div class="cd-flipcard-face-content"><p>${escapeHtml(card.front || 'Front')}</p></div>

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -31,7 +31,9 @@ const elements = {
   embedModal: document.getElementById('embedModal'),
   embedModalDialog: document.getElementById('embedModalDialog'),
   statusToast: document.getElementById('statusToast'),
-  animationToggle: document.getElementById('animationToggle')
+  animationToggle: document.getElementById('animationToggle'),
+  appMain: document.querySelector('.app-main'),
+  previewToggleButtons: Array.from(document.querySelectorAll('[data-preview-toggle]'))
 };
 
 const focusableModalSelector = [
@@ -46,6 +48,8 @@ const focusableModalSelector = [
 const modalState = {
   lastFocusedElement: null
 };
+
+let previewHidden = false;
 
 const isElementVisible = (element) => {
   if (!element) return false;
@@ -138,9 +142,36 @@ const refreshPreview = () => {
   if (!activity) return;
   const shouldPlayAnimations = elements.animationToggle ? elements.animationToggle.checked : true;
   activity.renderPreview(elements.previewArea, state.data, {
-
+    playAnimations: shouldPlayAnimations
   });
 };
+
+const updatePreviewToggleButtons = () => {
+  if (!Array.isArray(elements.previewToggleButtons)) {
+    return;
+  }
+  const label = previewHidden ? 'Show preview' : 'Hide preview';
+  const ariaLabel = previewHidden ? 'Show live preview panel' : 'Hide live preview panel';
+  elements.previewToggleButtons.forEach((button) => {
+    if (!button) return;
+    button.textContent = label;
+    button.setAttribute('aria-pressed', previewHidden ? 'true' : 'false');
+    button.setAttribute('aria-label', ariaLabel);
+  });
+};
+
+const setPreviewHidden = (hidden) => {
+  previewHidden = hidden;
+  if (elements.appMain) {
+    elements.appMain.classList.toggle('preview-hidden', previewHidden);
+  }
+  updatePreviewToggleButtons();
+  if (!previewHidden) {
+    refreshPreview();
+  }
+};
+
+updatePreviewToggleButtons();
 
 const rebuildEditor = () => {
   const activity = getActiveActivity();
@@ -568,6 +599,15 @@ const bindEvents = () => {
   if (elements.animationToggle) {
     elements.animationToggle.addEventListener('change', () => {
       refreshPreview();
+    });
+  }
+
+  if (Array.isArray(elements.previewToggleButtons)) {
+    elements.previewToggleButtons.forEach((button) => {
+      if (!button) return;
+      button.addEventListener('click', () => {
+        setPreviewHidden(!previewHidden);
+      });
     });
   }
 };

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -131,6 +131,7 @@ body::before {
   grid-template-columns: minmax(320px, var(--panel-width)) 1fr;
   gap: 0;
   min-height: 620px;
+  align-items: flex-start;
 }
 
 .control-panel {
@@ -399,6 +400,38 @@ textarea:focus {
   gap: 14px;
 }
 
+.card-color-field.card-color-field--locked {
+  opacity: 0.6;
+}
+
+.card-sync-toggle {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: var(--radius-xs);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  background: rgba(15, 23, 42, 0.04);
+}
+
+.card-sync-toggle input[type='checkbox'] {
+  width: 18px;
+  height: 18px;
+  accent-color: var(--accent);
+}
+
+.card-sync-text {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.card-sync-title {
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--text);
+}
+
 .card-image-field {
   gap: 12px;
 }
@@ -489,12 +522,24 @@ textarea:focus {
 }
 
 .preview-panel {
-  position: relative;
+  position: sticky;
+  top: 24px;
+  align-self: flex-start;
   padding: 28px 32px 36px;
   background: rgba(255, 255, 255, 0.85);
   display: flex;
   flex-direction: column;
   gap: 24px;
+  height: calc(100vh - 56px);
+  max-height: calc(100vh - 56px);
+}
+
+.app-main.preview-hidden {
+  grid-template-columns: minmax(320px, 1fr);
+}
+
+.app-main.preview-hidden .preview-panel {
+  display: none;
 }
 
 .preview-header {
@@ -513,6 +558,7 @@ textarea:focus {
   padding: 32px;
   overflow: auto;
   box-shadow: inset 0 6px 20px rgba(15, 23, 42, 0.04);
+  min-height: 0;
 }
 
 .empty-state {
@@ -880,7 +926,7 @@ textarea:focus {
 .hotspot-overlay {
   position: absolute;
   inset: 0;
-  pointer-events: none;
+  pointer-events: auto;
 }
 
 .hotspot-marker {
@@ -955,6 +1001,16 @@ textarea:focus {
   .control-panel {
     border-right: none;
     border-bottom: 1px solid rgba(15, 23, 42, 0.08);
+  }
+
+  .preview-panel {
+    position: static;
+    height: auto;
+    max-height: none;
+  }
+
+  .app-main.preview-hidden {
+    grid-template-columns: 1fr;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -22,6 +22,9 @@
         </div>
         <div class="header-actions">
           <button id="newProjectBtn" class="ghost-button" type="button">New activity</button>
+          <button class="ghost-button" type="button" data-preview-toggle="true" aria-pressed="false">
+            Hide preview
+          </button>
           <button
             id="showEmbedBtn"
             class="primary-button"
@@ -84,7 +87,11 @@
               <h2 class="panel-title">Live preview</h2>
               <p class="hint">Changes update in real time. Try interactions just like your learners will.</p>
             </div>
-            <div class="preview-tools"></div>
+            <div class="preview-tools">
+              <button class="ghost-button" type="button" data-preview-toggle="true" aria-pressed="false">
+                Hide preview
+              </button>
+            </div>
           </div>
           <div id="previewArea" class="preview-area">
             <div class="empty-state">


### PR DESCRIPTION
## Summary
- make the live preview column sticky, add hide/show toggles, and expand the editor when the preview is hidden
- add a Card 1 color sync option that locks other flip-card color pickers and keeps previews/embed output in sync
- allow hotspot markers to be repositioned again by enabling pointer events on the overlay

## Testing
- No automated tests were run (project has no test suite)


------
https://chatgpt.com/codex/tasks/task_e_68d680403510832ba4f5c0f095061239