### PR TITLE
Fix locked card appearance styles

### DIFF
--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -400,6 +400,11 @@ textarea:focus {
   gap: 14px;
 }
 
+/* Keep the lock indicator visible while soft-disabling the controls */
+.card-face-controls--locked {
+  opacity: 0.85;
+}
+
 .card-color-field.card-color-field--locked {
   opacity: 0.6;
 }


### PR DESCRIPTION
## Summary
- restore the locked flip card controls styling with explanatory comment
- retain the locked color field opacity before the card sync toggle rules

## Testing
- `rg "<<<<<<<" -n`


------
https://chatgpt.com/codex/tasks/task_e_68d68ed42ba8832b85f7fe4160120a8f