### PR TITLE
Fix embed payload transport to avoid proxy errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ docs/
 - The app uses vanilla JavaScript modules (`type="module"`) so it can run from the filesystem without a build step.
 - Activity editors encapsulate their own input rendering logic to avoid conflicts during concurrent development.
 - Embed snippets now render via a sandboxed iframe hitting `https://galvinradleyngo.github.io/canvasdesigner/embed.html`, keeping Canvas-compatible markup while isolating scripts and styles.
+- Payloads are encoded into the iframe URL hash instead of the query string so large activities are no longer rejected by LMS proxy layers that enforce strict request-length limits.
 - The hosted viewer validates the payload version, activity type, and text fields before rendering to guard against tampered URLs.
 
 ### Viewer base URL configuration

--- a/assets/js/embed.js
+++ b/assets/js/embed.js
@@ -104,7 +104,7 @@ export const generateEmbed = ({ type, title, description, data }) => {
 
   const encoded = encodePayload(payload);
   const viewerUrl = new URL(VIEWER_URL);
-  viewerUrl.searchParams.set('data', encoded);
+  viewerUrl.hash = encoded;
 
   const iframeTitle = escapeHtml(safeTitle || activity.label);
 


### PR DESCRIPTION
## Summary
- update the embed generator to place the encoded payload in the iframe URL hash instead of the query string, preventing Canvas/LMS proxies from rejecting large URLs with 502 errors
- document the change so future maintainers know why the hash transport is required

## Testing
- CANVASDESIGNER_VIEWER_BASE_URL='https://galvinradleyngo.github.io/canvasdesigner/' node - <<'NODE'
import { generateEmbed } from './assets/js/embed.js';
const html = generateEmbed({
  type: 'hotspots',
  title: 'Test',
  description: 'desc',
  data: { markers: [] }
});
console.log(html);
NODE

------
https://chatgpt.com/codex/tasks/task_e_68d6931b5680832bbcc574b7cd176a50