### PR TITLE
Restore flip card animation default

### DIFF
--- a/assets/js/activities/flipCards.js
+++ b/assets/js/activities/flipCards.js
@@ -415,7 +415,7 @@ const buildEditor = (container, data, onUpdate) => {
 const renderPreview = (container, data, options = {}) => {
   container.innerHTML = '';
   const working = ensureWorkingState(data);
-  const playAnimations = Boolean(options && options.playAnimations);
+  const playAnimations = options.playAnimations !== false;
   if (!working.cards.length) {
     const empty = document.createElement('div');
     empty.className = 'empty-state';

--- a/docs/assets/js/activities/flipCards.js
+++ b/docs/assets/js/activities/flipCards.js
@@ -415,7 +415,7 @@ const buildEditor = (container, data, onUpdate) => {
 const renderPreview = (container, data, options = {}) => {
   container.innerHTML = '';
   const working = ensureWorkingState(data);
-  const playAnimations = Boolean(options && options.playAnimations);
+  const playAnimations = options.playAnimations !== false;
   if (!working.cards.length) {
     const empty = document.createElement('div');
     empty.className = 'empty-state';


### PR DESCRIPTION
## Summary
- default flip card previews to play animations unless explicitly disabled in both authoring and docs bundles

## Testing
- manual verification in the authoring UI

------
https://chatgpt.com/codex/tasks/task_e_68d6942a5d0c832b8aa2327b0aedb215