### PR TITLE
Improve embed payload relay and viewer hydration

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ docs/
 - The app uses vanilla JavaScript modules (`type="module"`) so it can run from the filesystem without a build step.
 - Activity editors encapsulate their own input rendering logic to avoid conflicts during concurrent development.
 - Embed snippets now render via a sandboxed iframe hitting `https://galvinradleyngo.github.io/canvasdesigner/embed.html`, keeping Canvas-compatible markup while isolating scripts and styles.
+- Embed snippets register a lightweight relay script that streams the payload to the viewer via `postMessage`, keeping the iframe `src` short enough for strict LMS proxies while still embedding a hash fallback for older snippets.
+- Saved activities embed their project identifier so the hosted viewer can pull the latest data from Firestore on load, ensuring Canvas reflects edits without re-copying the snippet.
 - The hosted viewer validates the payload version, activity type, and text fields before rendering to guard against tampered URLs.
 
 ### Viewer base URL configuration

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ docs/
 - Activity editors encapsulate their own input rendering logic to avoid conflicts during concurrent development.
 - Embed snippets now render via a sandboxed iframe hitting `https://galvinradleyngo.github.io/canvasdesigner/embed.html`, keeping Canvas-compatible markup while isolating scripts and styles.
 - Embed snippets register a lightweight relay script that streams the payload to the viewer via `postMessage`, keeping the iframe `src` short enough for strict LMS proxies while still encoding the payload in the URL hash so older snippets keep working.
+- Payloads are encoded into the iframe URL hash instead of the query string so large activities are no longer rejected by LMS proxy layers that enforce strict request-length limits.
 - Saved activities embed their project identifier so the hosted viewer can pull the latest data from Firestore on load, ensuring Canvas reflects edits without re-copying the snippet.
 - The hosted viewer validates the payload version, activity type, and text fields before rendering to guard against tampered URLs.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ docs/
 - The app uses vanilla JavaScript modules (`type="module"`) so it can run from the filesystem without a build step.
 - Activity editors encapsulate their own input rendering logic to avoid conflicts during concurrent development.
 - Embed snippets now render via a sandboxed iframe hitting `https://galvinradleyngo.github.io/canvasdesigner/embed.html`, keeping Canvas-compatible markup while isolating scripts and styles.
-- Embed snippets register a lightweight relay script that streams the payload to the viewer via `postMessage`, keeping the iframe `src` short enough for strict LMS proxies while still embedding a hash fallback for older snippets.
+- Embed snippets register a lightweight relay script that streams the payload to the viewer via `postMessage`, keeping the iframe `src` short enough for strict LMS proxies while still encoding the payload in the URL hash so older snippets keep working.
 - Saved activities embed their project identifier so the hosted viewer can pull the latest data from Firestore on load, ensuring Canvas reflects edits without re-copying the snippet.
 - The hosted viewer validates the payload version, activity type, and text fields before rendering to guard against tampered URLs.
 

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -121,6 +121,7 @@ const updateActivityTabs = () => {
 const refreshEmbed = () => {
   try {
     const embed = generateEmbed({
+      id: state.id,
       type: state.type,
       title: state.title,
       description: state.description,

--- a/assets/js/embed.js
+++ b/assets/js/embed.js
@@ -1,5 +1,5 @@
 import { activities } from './activities/index.js';
-import { escapeHtml } from './utils.js';
+import { escapeHtml, uid } from './utils.js';
 
 const ensureTrailingSlash = (value) => (value.endsWith('/') ? value : `${value}/`);
 
@@ -86,7 +86,14 @@ const encodePayload = (payload) => {
   return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
 };
 
-export const generateEmbed = ({ type, title, description, data }) => {
+const serializeForScript = (value) => {
+  const json = JSON.stringify(value);
+  return json.replace(/</g, '\\u003c');
+};
+
+const EMBED_REGISTRY_KEY = '__CANVAS_DESIGNER_EMBEDS__';
+
+export const generateEmbed = ({ id, type, title, description, data }) => {
   const activity = activities[type];
   if (!activity) {
     throw new Error('Unknown activity type');
@@ -96,6 +103,7 @@ export const generateEmbed = ({ type, title, description, data }) => {
   const safeDescription = sanitizeText(description, { maxLength: 1200 });
   const payload = {
     v: 1,
+    ...(id ? { id } : {}),
     type,
     title: safeTitle,
     description: safeDescription,
@@ -104,18 +112,52 @@ export const generateEmbed = ({ type, title, description, data }) => {
 
   const encoded = encodePayload(payload);
   const viewerUrl = new URL(VIEWER_URL);
-  viewerUrl.searchParams.set('data', encoded);
+  const embedId = uid('cd-embed');
+  viewerUrl.searchParams.set('embedId', embedId);
+  viewerUrl.hash = encoded;
 
   const iframeTitle = escapeHtml(safeTitle || activity.label);
+  const serializedPayload = serializeForScript(payload);
+  const scriptContent = `(() => {
+    const registryKey = '${EMBED_REGISTRY_KEY}';
+    const store = (window[registryKey] = window[registryKey] || { items: {}, listener: null });
+    store.items['${embedId}'] = ${serializedPayload};
+    if (!store.listener) {
+      store.listener = (event) => {
+        const message = event?.data;
+        if (!message || message.type !== 'canvas-designer:request-payload') {
+          return;
+        }
+        const item = store.items[message.id];
+        if (!item) {
+          return;
+        }
+        const frame = document.getElementById(message.id);
+        if (!frame || frame.contentWindow !== event.source) {
+          return;
+        }
+        event.source?.postMessage({
+          type: 'canvas-designer:deliver-payload',
+          id: message.id,
+          payload: item
+        }, '*');
+      };
+      window.addEventListener('message', store.listener);
+    }
+  })();`;
 
   return `<!-- Canvas Designer Studio embed: ${iframeTitle} -->
 <iframe
   class="cd-embed-frame"
   title="${iframeTitle}"
+  id="${embedId}"
   loading="lazy"
   referrerpolicy="no-referrer"
   sandbox="allow-scripts allow-same-origin"
   style="width: 100%; min-height: 420px; border: 0; border-radius: 12px; overflow: hidden;"
   src="${viewerUrl.toString()}"
-></iframe>`;
+></iframe>
+<script type="text/javascript">
+${scriptContent}
+</script>`;
 };

--- a/assets/js/embed.js
+++ b/assets/js/embed.js
@@ -112,6 +112,9 @@ export const generateEmbed = ({ id, type, title, description, data }) => {
 
   const encoded = encodePayload(payload);
   const viewerUrl = new URL(VIEWER_URL);
+  // The embedId query parameter is how the viewer pairs postMessage payload
+  // requests with the matching iframe instance, so it must remain in the URL
+  // even though the activity data now travels in the hash segment.
   const embedId = uid('cd-embed');
   viewerUrl.searchParams.set('embedId', embedId);
   viewerUrl.hash = encoded;

--- a/assets/js/embed.js
+++ b/assets/js/embed.js
@@ -93,6 +93,16 @@ const serializeForScript = (value) => {
 
 const EMBED_REGISTRY_KEY = '__CANVAS_DESIGNER_EMBEDS__';
 
+const createViewerUrlWithEmbedId = () => {
+  const url = new URL(VIEWER_URL);
+  // The embedId query parameter is how the viewer pairs postMessage payload
+  // requests with the matching iframe instance, so it must remain in the URL
+  // even though the activity data now travels in the hash segment.
+  const embedId = uid('cd-embed');
+  url.searchParams.set('embedId', embedId);
+  return { url, embedId };
+};
+
 export const generateEmbed = ({ id, type, title, description, data }) => {
   const activity = activities[type];
   if (!activity) {
@@ -111,12 +121,7 @@ export const generateEmbed = ({ id, type, title, description, data }) => {
   };
 
   const encoded = encodePayload(payload);
-  const viewerUrl = new URL(VIEWER_URL);
-  // The embedId query parameter is how the viewer pairs postMessage payload
-  // requests with the matching iframe instance, so it must remain in the URL
-  // even though the activity data now travels in the hash segment.
-  const embedId = uid('cd-embed');
-  viewerUrl.searchParams.set('embedId', embedId);
+  const { url: viewerUrl, embedId } = createViewerUrlWithEmbedId();
   viewerUrl.hash = encoded;
 
   const iframeTitle = escapeHtml(safeTitle || activity.label);


### PR DESCRIPTION
## Summary
- stream embed payloads to the viewer through a postMessage relay script so hotspot embeds no longer hit LMS proxy limits
- include the saved project id in generated snippets and teach the viewer to hydrate content from Firestore so Canvas reflects subsequent edits automatically
- fall back to inline payloads when needed while keeping the viewer bootstrap async and resilient to missing data

## Testing
- CANVASDESIGNER_VIEWER_BASE_URL='https://galvinradleyngo.github.io/canvasdesigner/' node - <<'NODE'
import { generateEmbed } from './assets/js/embed.js';
import { hotspots } from './assets/js/activities/hotspots.js';
const data = hotspots.template();
const html = generateEmbed({ id: 'demo123', type:'hotspots', title:'Hotspot', description:'desc', data});
console.log(html.includes('canvas-designer:request-payload'));
console.log(html.includes('embedId='));
console.log(html.length);
NODE

------
https://chatgpt.com/codex/tasks/task_e_68d6931b5680832bbcc574b7cd176a50