### PR TITLE
Add accordion and timeline activities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Canvas Designer Studio
 
-Canvas Designer Studio is a modern single-page web app for crafting interactive learning activities that can be embedded in Canvas LMS. It provides visual editors, live previews, and copy-ready embed code for three activity types: flip cards, drag & drop, and hotspots.
+Canvas Designer Studio is a modern single-page web app for crafting interactive learning activities that can be embedded in Canvas LMS. It provides visual editors, live previews, and copy-ready embed code for five activity types: flip cards, accordion reveals, timelines, drag & drop, and hotspots.
 
 ## Features
 
-- 🎯 **Activity builder** – Guided authoring panels for flip cards, drag & drop matchers, and hotspot explorations.
+- 🎯 **Activity builder** – Guided authoring panels for flip cards, accordions, timelines, drag & drop matchers, and hotspot explorations.
 - ✨ **Live preview** – Interactions update in real time with accessible controls and animation toggles.
 - ☁️ **Cloud saving** – Store and retrieve activities securely in Firebase so they follow you across devices.
 - 🔗 **Canvas-ready embed code** – Generates an iframe snippet that loads a hosted viewer suitable for Canvas LMS (or any LMS that accepts iframe embeds).
@@ -37,6 +37,8 @@ assets/
     activities/
       index.js        # Activity registry
       flipCards.js    # Flip card editor + renderer
+      accordion.js    # Accordion editor + renderer
+      timeline.js     # Timeline editor + renderer
       dragDrop.js     # Drag & drop editor + renderer
       hotspots.js     # Hotspot editor + renderer
 docs/

--- a/assets/js/activities/accordion.js
+++ b/assets/js/activities/accordion.js
@@ -1,0 +1,383 @@
+import { clone, uid, escapeHtml } from '../utils.js';
+
+const createItem = (overrides = {}, index = 0) => {
+  const base = {
+    id: uid('accordion-item'),
+    title: `Section ${index + 1}`,
+    body: 'Add supporting details for learners.'
+  };
+  const item = { ...base, ...overrides };
+  if (!item.id) {
+    item.id = uid('accordion-item');
+  }
+  if (typeof item.title !== 'string') {
+    item.title = '';
+  }
+  if (typeof item.body !== 'string') {
+    item.body = '';
+  }
+  return item;
+};
+
+const normaliseItems = (items) => {
+  if (!Array.isArray(items)) {
+    return [];
+  }
+  return items.map((item, index) => createItem(item, index));
+};
+
+const createSampleItems = () =>
+  normaliseItems([
+    {
+      title: 'Key idea',
+      body: 'Summarise the concept or introduce the topic you want learners to explore.'
+    },
+    {
+      title: 'Deep dive',
+      body: 'Offer extra context, worked examples, or a helpful mnemonic to remember.'
+    },
+    {
+      title: 'Try this',
+      body: 'Add a reflection question or quick challenge to check understanding.'
+    }
+  ]);
+
+const template = () => ({
+  items: createSampleItems()
+});
+
+const example = () => ({
+  items: normaliseItems([
+    {
+      title: 'Step 1: Observe',
+      body: 'Explore the image and note anything that stands out. Jot down questions that come to mind.'
+    },
+    {
+      title: 'Step 2: Interpret',
+      body: 'Connect your observations to prior knowledge. What explanations could fit what you see?'
+    },
+    {
+      title: 'Step 3: Discuss',
+      body: 'Share your ideas with a partner or small group. Build on each other’s thinking.'
+    }
+  ])
+});
+
+const ensureWorkingState = (data) => {
+  const safe = data ? clone(data) : {};
+  return {
+    items: normaliseItems(safe.items)
+  };
+};
+
+const buildEditor = (container, data, onUpdate) => {
+  const working = ensureWorkingState(data);
+
+  const emit = (refresh = true) => {
+    onUpdate(clone(working));
+    if (refresh) {
+      rerender();
+    }
+  };
+
+  const rerender = () => {
+    container.innerHTML = '';
+
+    const addButton = document.createElement('button');
+    addButton.type = 'button';
+    addButton.className = 'ghost-button';
+    addButton.textContent = 'Add section';
+    addButton.addEventListener('click', () => {
+      working.items.push(createItem({ title: 'New section', body: '' }, working.items.length));
+      emit();
+    });
+
+    if (!working.items.length) {
+      const empty = document.createElement('div');
+      empty.className = 'empty-state';
+      empty.innerHTML = '<p>No sections yet. Click “Add section” to begin.</p>';
+      container.append(empty);
+    }
+
+    working.items.forEach((item, index) => {
+      const editorItem = document.createElement('div');
+      editorItem.className = 'editor-item';
+
+      const header = document.createElement('div');
+      header.className = 'editor-item-header';
+      header.innerHTML = `<span>Section ${index + 1}</span>`;
+
+      const actions = document.createElement('div');
+      actions.className = 'editor-item-actions';
+
+      const duplicateBtn = document.createElement('button');
+      duplicateBtn.type = 'button';
+      duplicateBtn.className = 'muted-button';
+      duplicateBtn.textContent = 'Duplicate';
+      duplicateBtn.addEventListener('click', () => {
+        const cloneSource = clone(item);
+        working.items.splice(index + 1, 0, createItem({ ...cloneSource, id: uid('accordion-item') }, index + 1));
+        emit();
+      });
+
+      const deleteBtn = document.createElement('button');
+      deleteBtn.type = 'button';
+      deleteBtn.className = 'muted-button';
+      deleteBtn.textContent = 'Remove';
+      deleteBtn.addEventListener('click', () => {
+        working.items.splice(index, 1);
+        emit();
+      });
+
+      actions.append(duplicateBtn, deleteBtn);
+      header.append(actions);
+
+      const titleField = document.createElement('label');
+      titleField.className = 'field';
+      titleField.innerHTML = '<span class="field-label">Title</span>';
+      const titleInput = document.createElement('input');
+      titleInput.type = 'text';
+      titleInput.className = 'text-input';
+      titleInput.value = item.title;
+      titleInput.placeholder = 'e.g. Why it matters';
+      titleInput.addEventListener('input', () => {
+        working.items[index].title = titleInput.value;
+        emit(false);
+      });
+      titleField.append(titleInput);
+
+      const bodyField = document.createElement('label');
+      bodyField.className = 'field';
+      bodyField.innerHTML = '<span class="field-label">Body text</span>';
+      const bodyInput = document.createElement('textarea');
+      bodyInput.rows = 3;
+      bodyInput.value = item.body;
+      bodyInput.placeholder = 'Add the supporting explanation or prompt for this section.';
+      bodyInput.addEventListener('input', () => {
+        working.items[index].body = bodyInput.value;
+        emit(false);
+      });
+      bodyField.append(bodyInput);
+
+      editorItem.append(header, titleField, bodyField);
+      container.append(editorItem);
+    });
+
+    container.append(addButton);
+  };
+
+  rerender();
+};
+
+const renderPreview = (container, data, options = {}) => {
+  container.innerHTML = '';
+  const working = ensureWorkingState(data);
+  const playAnimations = options.playAnimations !== false;
+
+  if (!working.items.length) {
+    const empty = document.createElement('div');
+    empty.className = 'empty-state';
+    empty.innerHTML = '<p>Add accordion sections to see the preview.</p>';
+    container.append(empty);
+    return;
+  }
+
+  const wrapper = document.createElement('div');
+  wrapper.className = 'accordion';
+
+  const items = working.items.map((item, index) => {
+    const details = document.createElement('details');
+    details.className = 'accordion-item';
+    details.dataset.index = String(index);
+    if (index === 0) {
+      details.open = true;
+    }
+    if (playAnimations) {
+      details.classList.add('animate');
+      details.style.setProperty('--item-index', String(index));
+    }
+
+    const summary = document.createElement('summary');
+    summary.className = 'accordion-summary';
+
+    const title = document.createElement('span');
+    title.className = 'accordion-title';
+    title.textContent = typeof item.title === 'string' ? item.title : '';
+
+    const icon = document.createElement('span');
+    icon.className = 'accordion-icon';
+    icon.setAttribute('aria-hidden', 'true');
+
+    summary.append(title, icon);
+
+    const content = document.createElement('div');
+    content.className = 'accordion-content';
+    const body = document.createElement('div');
+    body.className = 'accordion-body';
+    body.textContent = typeof item.body === 'string' ? item.body : '';
+    content.append(body);
+
+    details.append(summary, content);
+    wrapper.append(details);
+    return details;
+  });
+
+  wrapper.addEventListener('toggle', (event) => {
+    const target = event.target;
+    if (!target || target.tagName !== 'DETAILS' || !target.open) {
+      return;
+    }
+    items.forEach((item) => {
+      if (item !== target) {
+        item.open = false;
+      }
+    });
+  });
+
+  container.append(wrapper);
+};
+
+const embedTemplate = (data, containerId) => {
+  const working = ensureWorkingState(data);
+  const items = working.items.length ? working.items : createSampleItems();
+  return {
+    html: `
+    <div class="cd-accordion">
+      ${items
+        .map(
+          (item, index) => `
+        <details class="cd-accordion-item animate" ${index === 0 ? 'open' : ''}>
+          <summary class="cd-accordion-summary">
+            <span class="cd-accordion-title">${
+              typeof item.title === 'string' ? escapeHtml(item.title) : ''
+            }</span>
+            <span class="cd-accordion-icon" aria-hidden="true"></span>
+          </summary>
+          <div class="cd-accordion-content">
+            <div class="cd-accordion-body">${
+              typeof item.body === 'string' ? escapeHtml(item.body) : ''
+            }</div>
+          </div>
+        </details>`
+        )
+        .join('')}
+    </div>
+  `,
+    css: `
+    #${containerId} .cd-accordion {
+      display: flex;
+      flex-direction: column;
+      gap: 0.8rem;
+    }
+    #${containerId} .cd-accordion-item {
+      border-radius: 16px;
+      border: 1px solid rgba(99, 102, 241, 0.15);
+      background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(248, 250, 252, 0.9));
+      box-shadow: 0 18px 38px rgba(15, 23, 42, 0.12);
+      overflow: hidden;
+      transition: box-shadow 200ms ease, border-color 200ms ease;
+    }
+    #${containerId} .cd-accordion-item[open] {
+      border-color: rgba(99, 102, 241, 0.35);
+      box-shadow: 0 20px 44px rgba(99, 102, 241, 0.18);
+    }
+    #${containerId} .cd-accordion-summary {
+      position: relative;
+      list-style: none;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1.2rem;
+      padding: 1.1rem 1.4rem;
+      font-weight: 600;
+      font-size: 1rem;
+      cursor: pointer;
+    }
+    #${containerId} .cd-accordion-summary::-webkit-details-marker {
+      display: none;
+    }
+    #${containerId} .cd-accordion-title {
+      flex: 1;
+      min-width: 0;
+    }
+    #${containerId} .cd-accordion-icon {
+      width: 2rem;
+      height: 2rem;
+      border-radius: 999px;
+      background: rgba(99, 102, 241, 0.12);
+      color: #6366f1;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      transition: transform 220ms ease;
+    }
+    #${containerId} .cd-accordion-icon::before {
+      content: '';
+      width: 10px;
+      height: 10px;
+      border: 2px solid currentColor;
+      border-top: 0;
+      border-right: 0;
+      transform: rotate(-45deg);
+      margin-top: -2px;
+    }
+    #${containerId} .cd-accordion-item[open] .cd-accordion-icon {
+      transform: rotate(180deg);
+    }
+    #${containerId} .cd-accordion-content {
+      padding: 0 1.4rem 1.2rem;
+      color: rgba(15, 23, 42, 0.8);
+      font-size: 0.95rem;
+    }
+    #${containerId} .cd-accordion-body {
+      margin: 0;
+      white-space: pre-wrap;
+      line-height: 1.55;
+    }
+    #${containerId} .cd-accordion-item.animate {
+      animation: cd-accordion-reveal 420ms cubic-bezier(0.22, 0.61, 0.36, 1) both;
+      animation-delay: calc(var(--item-index, 0) * 90ms);
+    }
+    @keyframes cd-accordion-reveal {
+      from {
+        opacity: 0;
+        transform: translateY(10px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+  `,
+    js: `
+    (function(){
+      const root = document.getElementById('${containerId}');
+      if (!root) return;
+      const items = Array.from(root.querySelectorAll('.cd-accordion-item'));
+      items.forEach((item) => {
+        item.addEventListener('toggle', () => {
+          if (!item.open) {
+            return;
+          }
+          item.classList.remove('animate');
+          items.forEach((other) => {
+            if (other !== item) {
+              other.removeAttribute('open');
+            }
+          });
+        });
+      });
+    })();
+  `
+  };
+};
+
+export const accordion = {
+  id: 'accordion',
+  label: 'Accordion',
+  template,
+  example,
+  buildEditor,
+  renderPreview,
+  embedTemplate
+};

--- a/assets/js/activities/flipCards.js
+++ b/assets/js/activities/flipCards.js
@@ -467,7 +467,8 @@ const renderPreview = (container, data, options = {}) => {
       const textWrapper = document.createElement('div');
       textWrapper.className = 'flipcard-face-content';
       const paragraph = document.createElement('p');
-      paragraph.textContent = card[faceKey] || fallbackText;
+      const value = card[faceKey];
+      paragraph.textContent = typeof value === 'string' ? value : fallbackText;
       textWrapper.append(paragraph);
       face.append(textWrapper);
       return face;
@@ -540,13 +541,17 @@ const embedTemplate = (data, containerId) => {
                 card.frontColor || DEFAULT_FRONT_COLORS[(useSyncedColors ? 0 : index) % DEFAULT_FRONT_COLORS.length]
               )};">
                 ${card.frontImage ? `<img src="${escapeHtml(card.frontImage)}" alt="" />` : ''}
-                <div class="cd-flipcard-face-content"><p>${escapeHtml(card.front || 'Front')}</p></div>
+                <div class="cd-flipcard-face-content"><p>${
+                  typeof card.front === 'string' ? escapeHtml(card.front) : 'Front'
+                }</p></div>
               </div>
               <div class="cd-flipcard-face cd-flipcard-back${card.backImage ? ' has-image' : ''}" style="background: ${escapeHtml(
                 card.backColor || DEFAULT_BACK_COLOR
               )};">
                 ${card.backImage ? `<img src="${escapeHtml(card.backImage)}" alt="" />` : ''}
-                <div class="cd-flipcard-face-content"><p>${escapeHtml(card.back || 'Back')}</p></div>
+                <div class="cd-flipcard-face-content"><p>${
+                  typeof card.back === 'string' ? escapeHtml(card.back) : 'Back'
+                }</p></div>
               </div>
             </div>
           </div>`
@@ -576,7 +581,7 @@ const embedTemplate = (data, containerId) => {
       min-height: 160px;
     }
     #${containerId} .cd-flipcard-inner.animate {
-      animation: cd-pulse-card 12s ease-in-out infinite;
+      animation: cd-flipcard-preview 1.1s cubic-bezier(0.22, 0.61, 0.36, 1) both;
     }
     #${containerId} .cd-flipcard.flipped .cd-flipcard-inner {
       transform: rotateY(180deg);
@@ -653,13 +658,18 @@ const embedTemplate = (data, containerId) => {
         transform: translateY(0) scale(1);
       }
     }
-    @keyframes cd-pulse-card {
-      0%,
-      100% {
-        transform: translateY(0);
+    @keyframes cd-flipcard-preview {
+      0% {
+        transform: rotateY(0deg);
       }
-      50% {
-        transform: translateY(-6px);
+      45% {
+        transform: rotateY(180deg);
+      }
+      55% {
+        transform: rotateY(180deg);
+      }
+      100% {
+        transform: rotateY(0deg);
       }
     }
   `,

--- a/assets/js/activities/index.js
+++ b/assets/js/activities/index.js
@@ -1,11 +1,15 @@
 import { flipCards } from './flipCards.js';
 import { dragDrop } from './dragDrop.js';
 import { hotspots } from './hotspots.js';
+import { accordion } from './accordion.js';
+import { timeline } from './timeline.js';
 
 export const activities = {
   [flipCards.id]: flipCards,
   [dragDrop.id]: dragDrop,
-  [hotspots.id]: hotspots
+  [hotspots.id]: hotspots,
+  [accordion.id]: accordion,
+  [timeline.id]: timeline
 };
 
 export const defaultActivityId = flipCards.id;

--- a/assets/js/activities/timeline.js
+++ b/assets/js/activities/timeline.js
@@ -1,0 +1,409 @@
+import { clone, uid, escapeHtml } from '../utils.js';
+
+const DEFAULT_ACCENT = '#6366f1';
+
+const createEvent = (overrides = {}, index = 0) => {
+  const base = {
+    id: uid('timeline-event'),
+    title: `Milestone ${index + 1}`,
+    date: '',
+    description: 'Describe what happens during this moment.'
+  };
+  const event = { ...base, ...overrides };
+  if (!event.id) {
+    event.id = uid('timeline-event');
+  }
+  if (typeof event.title !== 'string') {
+    event.title = '';
+  }
+  if (typeof event.date !== 'string') {
+    event.date = '';
+  }
+  if (typeof event.description !== 'string') {
+    event.description = '';
+  }
+  return event;
+};
+
+const normaliseEvents = (events) => {
+  if (!Array.isArray(events)) {
+    return [];
+  }
+  return events.map((event, index) => createEvent(event, index));
+};
+
+const createSampleEvents = () =>
+  normaliseEvents([
+    {
+      title: 'Kickoff',
+      date: 'Week 1',
+      description: 'Introduce the project, form teams, and clarify success criteria.'
+    },
+    {
+      title: 'Research',
+      date: 'Weeks 2-3',
+      description: 'Gather sources, conduct interviews, and capture findings in the shared notebook.'
+    },
+    {
+      title: 'Prototype + feedback',
+      date: 'Week 4',
+      description: 'Build a rough draft, collect peer feedback, and iterate before the final submission.'
+    }
+  ]);
+
+const template = () => ({
+  accentColor: DEFAULT_ACCENT,
+  events: createSampleEvents()
+});
+
+const example = () => ({
+  accentColor: '#0ea5e9',
+  events: normaliseEvents([
+    {
+      title: 'Question launched',
+      date: 'Monday',
+      description: 'Students review the driving question and brainstorm what they already know.'
+    },
+    {
+      title: 'Investigation',
+      date: 'Tuesday – Wednesday',
+      description: 'Teams collect evidence from labs, readings, or field work to answer the question.'
+    },
+    {
+      title: 'Synthesis',
+      date: 'Thursday',
+      description: 'Groups organise findings into a story or argument using the evidence they gathered.'
+    },
+    {
+      title: 'Showcase',
+      date: 'Friday',
+      description: 'Learners present their conclusions and reflect on new questions that emerged.'
+    }
+  ])
+});
+
+const ensureWorkingState = (data) => {
+  const safe = data ? clone(data) : {};
+  const accent =
+    typeof safe.accentColor === 'string' && safe.accentColor.trim() ? safe.accentColor.trim() : DEFAULT_ACCENT;
+  return {
+    accentColor: accent,
+    events: normaliseEvents(safe.events)
+  };
+};
+
+const buildEditor = (container, data, onUpdate) => {
+  const working = ensureWorkingState(data);
+
+  const emit = (refresh = true) => {
+    onUpdate(clone(working));
+    if (refresh) {
+      rerender();
+    }
+  };
+
+  const rerender = () => {
+    container.innerHTML = '';
+
+    const appearanceItem = document.createElement('div');
+    appearanceItem.className = 'editor-item';
+    const appearanceField = document.createElement('label');
+    appearanceField.className = 'field';
+    appearanceField.innerHTML = '<span class="field-label">Accent color</span>';
+    const colorInput = document.createElement('input');
+    colorInput.type = 'color';
+    colorInput.className = 'color-input';
+    colorInput.value = working.accentColor;
+    colorInput.addEventListener('input', () => {
+      working.accentColor = colorInput.value;
+      emit(false);
+    });
+    appearanceField.append(colorInput);
+    appearanceItem.append(appearanceField);
+    container.append(appearanceItem);
+
+    const addButton = document.createElement('button');
+    addButton.type = 'button';
+    addButton.className = 'ghost-button';
+    addButton.textContent = 'Add event';
+    addButton.addEventListener('click', () => {
+      working.events.push(createEvent({ title: 'New milestone', description: '' }, working.events.length));
+      emit();
+    });
+
+    if (!working.events.length) {
+      const empty = document.createElement('div');
+      empty.className = 'empty-state';
+      empty.innerHTML = '<p>No timeline events yet. Click “Add event” to create one.</p>';
+      container.append(empty);
+    }
+
+    working.events.forEach((event, index) => {
+      const editorItem = document.createElement('div');
+      editorItem.className = 'editor-item';
+
+      const header = document.createElement('div');
+      header.className = 'editor-item-header';
+      header.innerHTML = `<span>Event ${index + 1}</span>`;
+
+      const actions = document.createElement('div');
+      actions.className = 'editor-item-actions';
+
+      const duplicateBtn = document.createElement('button');
+      duplicateBtn.type = 'button';
+      duplicateBtn.className = 'muted-button';
+      duplicateBtn.textContent = 'Duplicate';
+      duplicateBtn.addEventListener('click', () => {
+        const cloneSource = clone(event);
+        working.events.splice(index + 1, 0, createEvent({ ...cloneSource, id: uid('timeline-event') }, index + 1));
+        emit();
+      });
+
+      const deleteBtn = document.createElement('button');
+      deleteBtn.type = 'button';
+      deleteBtn.className = 'muted-button';
+      deleteBtn.textContent = 'Remove';
+      deleteBtn.addEventListener('click', () => {
+        working.events.splice(index, 1);
+        emit();
+      });
+
+      actions.append(duplicateBtn, deleteBtn);
+      header.append(actions);
+
+      const titleField = document.createElement('label');
+      titleField.className = 'field';
+      titleField.innerHTML = '<span class="field-label">Title</span>';
+      const titleInput = document.createElement('input');
+      titleInput.type = 'text';
+      titleInput.className = 'text-input';
+      titleInput.value = event.title;
+      titleInput.placeholder = 'e.g. Draft submission';
+      titleInput.addEventListener('input', () => {
+        working.events[index].title = titleInput.value;
+        emit(false);
+      });
+      titleField.append(titleInput);
+
+      const dateField = document.createElement('label');
+      dateField.className = 'field';
+      dateField.innerHTML = '<span class="field-label">Date or label (optional)</span>';
+      const dateInput = document.createElement('input');
+      dateInput.type = 'text';
+      dateInput.className = 'text-input';
+      dateInput.value = event.date;
+      dateInput.placeholder = 'e.g. Week 2 or 14 Sept';
+      dateInput.addEventListener('input', () => {
+        working.events[index].date = dateInput.value;
+        emit(false);
+      });
+      dateField.append(dateInput);
+
+      const descriptionField = document.createElement('label');
+      descriptionField.className = 'field';
+      descriptionField.innerHTML = '<span class="field-label">Description</span>';
+      const descriptionInput = document.createElement('textarea');
+      descriptionInput.rows = 3;
+      descriptionInput.value = event.description;
+      descriptionInput.placeholder = 'Summarise the key tasks, resources, or goals for this event.';
+      descriptionInput.addEventListener('input', () => {
+        working.events[index].description = descriptionInput.value;
+        emit(false);
+      });
+      descriptionField.append(descriptionInput);
+
+      editorItem.append(header, titleField, dateField, descriptionField);
+      container.append(editorItem);
+    });
+
+    container.append(addButton);
+  };
+
+  rerender();
+};
+
+const renderPreview = (container, data, options = {}) => {
+  container.innerHTML = '';
+  const working = ensureWorkingState(data);
+  const playAnimations = options.playAnimations !== false;
+
+  if (!working.events.length) {
+    const empty = document.createElement('div');
+    empty.className = 'empty-state';
+    empty.innerHTML = '<p>Add timeline events to see the preview.</p>';
+    container.append(empty);
+    return;
+  }
+
+  const accent = working.accentColor || DEFAULT_ACCENT;
+  const wrapper = document.createElement('div');
+  wrapper.className = 'timeline';
+  wrapper.style.setProperty('--timeline-accent', accent);
+
+  working.events.forEach((event, index) => {
+    const item = document.createElement('div');
+    item.className = 'timeline-item';
+    if (playAnimations) {
+      item.classList.add('animate');
+      item.style.setProperty('--item-index', String(index));
+    }
+
+    const marker = document.createElement('div');
+    marker.className = 'timeline-marker';
+
+    const content = document.createElement('div');
+    content.className = 'timeline-content';
+
+    if (event.date) {
+      const date = document.createElement('span');
+      date.className = 'timeline-date';
+      date.textContent = event.date;
+      content.append(date);
+    }
+
+    const title = document.createElement('h3');
+    title.className = 'timeline-title';
+    title.textContent = event.title || '';
+    content.append(title);
+
+    if (event.description) {
+      const description = document.createElement('p');
+      description.className = 'timeline-description';
+      description.textContent = event.description;
+      content.append(description);
+    }
+
+    item.append(marker, content);
+    wrapper.append(item);
+  });
+
+  container.append(wrapper);
+};
+
+const embedTemplate = (data, containerId) => {
+  const working = ensureWorkingState(data);
+  const accent = working.accentColor || DEFAULT_ACCENT;
+  const events = working.events.length ? working.events : createSampleEvents();
+  return {
+    html: `
+    <div class="cd-timeline" style="--timeline-accent: ${escapeHtml(accent)};">
+      ${events
+        .map(
+          (event, index) => `
+        <div class="cd-timeline-item animate" style="--item-index: ${index};">
+          <div class="cd-timeline-marker"></div>
+          <div class="cd-timeline-content">
+            ${event.date ? `<span class="cd-timeline-date">${escapeHtml(event.date)}</span>` : ''}
+            <h3 class="cd-timeline-title">${
+              typeof event.title === 'string' ? escapeHtml(event.title) : ''
+            }</h3>
+            ${
+              event.description
+                ? `<p class="cd-timeline-description">${escapeHtml(event.description)}</p>`
+                : ''
+            }
+          </div>
+        </div>`
+        )
+        .join('')}
+    </div>
+  `,
+    css: `
+    #${containerId} .cd-timeline {
+      --timeline-accent: ${escapeHtml(accent)};
+      position: relative;
+      display: grid;
+      gap: 1.5rem;
+      padding-left: 1.6rem;
+    }
+    #${containerId} .cd-timeline::before {
+      content: '';
+      position: absolute;
+      left: 0.55rem;
+      top: 0.75rem;
+      bottom: 0.75rem;
+      width: 2px;
+      background: linear-gradient(180deg, rgba(99, 102, 241, 0.35), rgba(99, 102, 241, 0.05));
+    }
+    #${containerId} .cd-timeline-item {
+      position: relative;
+      display: grid;
+      grid-template-columns: min-content 1fr;
+      gap: 1.2rem;
+    }
+    #${containerId} .cd-timeline-item.animate {
+      animation: cd-timeline-reveal 460ms cubic-bezier(0.22, 0.61, 0.36, 1) both;
+      animation-delay: calc(var(--item-index, 0) * 110ms);
+    }
+    #${containerId} .cd-timeline-item::before {
+      content: '';
+      position: absolute;
+      left: 0.55rem;
+      top: 1.7rem;
+      bottom: -1.5rem;
+      width: 2px;
+      background: linear-gradient(180deg, rgba(148, 163, 184, 0.4), rgba(148, 163, 184, 0));
+    }
+    #${containerId} .cd-timeline-item:last-child::before {
+      display: none;
+    }
+    #${containerId} .cd-timeline-marker {
+      width: 1.15rem;
+      height: 1.15rem;
+      border-radius: 999px;
+      background: #ffffff;
+      border: 3px solid var(--timeline-accent);
+      box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.12);
+      margin-top: 0.4rem;
+    }
+    #${containerId} .cd-timeline-content {
+      background: rgba(255, 255, 255, 0.95);
+      border-radius: 16px;
+      padding: 1rem 1.3rem;
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      box-shadow: 0 16px 32px rgba(15, 23, 42, 0.14);
+    }
+    #${containerId} .cd-timeline-date {
+      display: inline-block;
+      font-size: 0.82rem;
+      font-weight: 600;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: var(--timeline-accent);
+      margin-bottom: 0.35rem;
+    }
+    #${containerId} .cd-timeline-title {
+      margin: 0;
+      font-size: 1.05rem;
+      color: #0f172a;
+    }
+    #${containerId} .cd-timeline-description {
+      margin: 0.45rem 0 0;
+      color: rgba(15, 23, 42, 0.78);
+      line-height: 1.6;
+      white-space: pre-wrap;
+    }
+    @keyframes cd-timeline-reveal {
+      from {
+        opacity: 0;
+        transform: translateY(12px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+  `,
+    js: ''
+  };
+};
+
+export const timeline = {
+  id: 'timeline',
+  label: 'Timeline',
+  template,
+  example,
+  buildEditor,
+  renderPreview,
+  embedTemplate
+};

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -601,16 +601,21 @@ textarea:focus {
 }
 
 .flipcard-inner.animate {
-  animation: pulse-card 12s ease-in-out infinite;
+  animation: flipcard-preview 1.1s cubic-bezier(0.22, 0.61, 0.36, 1) both;
 }
 
-@keyframes pulse-card {
-  0%,
-  100% {
-    transform: translateY(0);
+@keyframes flipcard-preview {
+  0% {
+    transform: rotateY(0deg);
   }
-  50% {
-    transform: translateY(-6px);
+  45% {
+    transform: rotateY(180deg);
+  }
+  55% {
+    transform: rotateY(180deg);
+  }
+  100% {
+    transform: rotateY(0deg);
   }
 }
 
@@ -695,6 +700,198 @@ textarea:focus {
 .flipcard-face-content p {
   margin: 0;
   line-height: 1.4;
+}
+
+.accordion {
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.accordion-item {
+  border-radius: 16px;
+  border: 1px solid rgba(99, 102, 241, 0.15);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.98), rgba(244, 246, 255, 0.92));
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.14);
+  overflow: hidden;
+  transition: box-shadow 220ms ease, border-color 220ms ease;
+}
+
+.accordion-item.animate {
+  animation: accordion-reveal 420ms cubic-bezier(0.22, 0.61, 0.36, 1) both;
+  animation-delay: calc(var(--item-index, 0) * 90ms);
+}
+
+.accordion-item[open] {
+  border-color: rgba(99, 102, 241, 0.32);
+  box-shadow: 0 22px 46px rgba(99, 102, 241, 0.2);
+}
+
+.accordion-summary {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.1rem;
+  padding: 1.1rem 1.4rem;
+  cursor: pointer;
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.accordion-summary::-webkit-details-marker {
+  display: none;
+}
+
+.accordion-title {
+  flex: 1;
+  min-width: 0;
+}
+
+.accordion-icon {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 999px;
+  background: rgba(99, 102, 241, 0.12);
+  color: #6366f1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: transform 220ms ease;
+}
+
+.accordion-icon::before {
+  content: '';
+  width: 10px;
+  height: 10px;
+  border: 2px solid currentColor;
+  border-top: 0;
+  border-right: 0;
+  transform: rotate(-45deg);
+  margin-top: -2px;
+}
+
+.accordion-item[open] .accordion-icon {
+  transform: rotate(180deg);
+}
+
+.accordion-content {
+  padding: 0 1.4rem 1.2rem;
+  color: rgba(15, 23, 42, 0.8);
+  font-size: 0.95rem;
+}
+
+.accordion-body {
+  margin: 0;
+  line-height: 1.55;
+  white-space: pre-wrap;
+}
+
+@keyframes accordion-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.timeline {
+  --timeline-accent: #6366f1;
+  position: relative;
+  display: grid;
+  gap: 1.5rem;
+  padding-left: 1.6rem;
+}
+
+.timeline::before {
+  content: '';
+  position: absolute;
+  left: 0.55rem;
+  top: 0.75rem;
+  bottom: 0.75rem;
+  width: 2px;
+  background: linear-gradient(180deg, rgba(99, 102, 241, 0.35), rgba(99, 102, 241, 0.05));
+}
+
+.timeline-item {
+  position: relative;
+  display: grid;
+  grid-template-columns: min-content 1fr;
+  gap: 1.2rem;
+}
+
+.timeline-item.animate {
+  animation: timeline-reveal 460ms cubic-bezier(0.22, 0.61, 0.36, 1) both;
+  animation-delay: calc(var(--item-index, 0) * 110ms);
+}
+
+.timeline-item::before {
+  content: '';
+  position: absolute;
+  left: 0.55rem;
+  top: 1.7rem;
+  bottom: -1.5rem;
+  width: 2px;
+  background: linear-gradient(180deg, rgba(148, 163, 184, 0.4), rgba(148, 163, 184, 0));
+}
+
+.timeline-item:last-child::before {
+  display: none;
+}
+
+.timeline-marker {
+  width: 1.15rem;
+  height: 1.15rem;
+  border-radius: 999px;
+  background: #ffffff;
+  border: 3px solid var(--timeline-accent);
+  box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.12);
+  margin-top: 0.4rem;
+}
+
+.timeline-content {
+  background: rgba(255, 255, 255, 0.95);
+  border-radius: 16px;
+  padding: 1rem 1.3rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.14);
+}
+
+.timeline-date {
+  display: inline-block;
+  font-size: 0.82rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--timeline-accent);
+  margin-bottom: 0.35rem;
+}
+
+.timeline-title {
+  margin: 0;
+  font-size: 1.05rem;
+  color: #0f172a;
+}
+
+.timeline-description {
+  margin: 0.45rem 0 0;
+  color: rgba(15, 23, 42, 0.78);
+  line-height: 1.6;
+  white-space: pre-wrap;
+}
+
+@keyframes timeline-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .hotspot-preview {

--- a/docs/assets/js/activities/accordion.js
+++ b/docs/assets/js/activities/accordion.js
@@ -1,0 +1,383 @@
+import { clone, uid, escapeHtml } from '../utils.js';
+
+const createItem = (overrides = {}, index = 0) => {
+  const base = {
+    id: uid('accordion-item'),
+    title: `Section ${index + 1}`,
+    body: 'Add supporting details for learners.'
+  };
+  const item = { ...base, ...overrides };
+  if (!item.id) {
+    item.id = uid('accordion-item');
+  }
+  if (typeof item.title !== 'string') {
+    item.title = '';
+  }
+  if (typeof item.body !== 'string') {
+    item.body = '';
+  }
+  return item;
+};
+
+const normaliseItems = (items) => {
+  if (!Array.isArray(items)) {
+    return [];
+  }
+  return items.map((item, index) => createItem(item, index));
+};
+
+const createSampleItems = () =>
+  normaliseItems([
+    {
+      title: 'Key idea',
+      body: 'Summarise the concept or introduce the topic you want learners to explore.'
+    },
+    {
+      title: 'Deep dive',
+      body: 'Offer extra context, worked examples, or a helpful mnemonic to remember.'
+    },
+    {
+      title: 'Try this',
+      body: 'Add a reflection question or quick challenge to check understanding.'
+    }
+  ]);
+
+const template = () => ({
+  items: createSampleItems()
+});
+
+const example = () => ({
+  items: normaliseItems([
+    {
+      title: 'Step 1: Observe',
+      body: 'Explore the image and note anything that stands out. Jot down questions that come to mind.'
+    },
+    {
+      title: 'Step 2: Interpret',
+      body: 'Connect your observations to prior knowledge. What explanations could fit what you see?'
+    },
+    {
+      title: 'Step 3: Discuss',
+      body: 'Share your ideas with a partner or small group. Build on each other’s thinking.'
+    }
+  ])
+});
+
+const ensureWorkingState = (data) => {
+  const safe = data ? clone(data) : {};
+  return {
+    items: normaliseItems(safe.items)
+  };
+};
+
+const buildEditor = (container, data, onUpdate) => {
+  const working = ensureWorkingState(data);
+
+  const emit = (refresh = true) => {
+    onUpdate(clone(working));
+    if (refresh) {
+      rerender();
+    }
+  };
+
+  const rerender = () => {
+    container.innerHTML = '';
+
+    const addButton = document.createElement('button');
+    addButton.type = 'button';
+    addButton.className = 'ghost-button';
+    addButton.textContent = 'Add section';
+    addButton.addEventListener('click', () => {
+      working.items.push(createItem({ title: 'New section', body: '' }, working.items.length));
+      emit();
+    });
+
+    if (!working.items.length) {
+      const empty = document.createElement('div');
+      empty.className = 'empty-state';
+      empty.innerHTML = '<p>No sections yet. Click “Add section” to begin.</p>';
+      container.append(empty);
+    }
+
+    working.items.forEach((item, index) => {
+      const editorItem = document.createElement('div');
+      editorItem.className = 'editor-item';
+
+      const header = document.createElement('div');
+      header.className = 'editor-item-header';
+      header.innerHTML = `<span>Section ${index + 1}</span>`;
+
+      const actions = document.createElement('div');
+      actions.className = 'editor-item-actions';
+
+      const duplicateBtn = document.createElement('button');
+      duplicateBtn.type = 'button';
+      duplicateBtn.className = 'muted-button';
+      duplicateBtn.textContent = 'Duplicate';
+      duplicateBtn.addEventListener('click', () => {
+        const cloneSource = clone(item);
+        working.items.splice(index + 1, 0, createItem({ ...cloneSource, id: uid('accordion-item') }, index + 1));
+        emit();
+      });
+
+      const deleteBtn = document.createElement('button');
+      deleteBtn.type = 'button';
+      deleteBtn.className = 'muted-button';
+      deleteBtn.textContent = 'Remove';
+      deleteBtn.addEventListener('click', () => {
+        working.items.splice(index, 1);
+        emit();
+      });
+
+      actions.append(duplicateBtn, deleteBtn);
+      header.append(actions);
+
+      const titleField = document.createElement('label');
+      titleField.className = 'field';
+      titleField.innerHTML = '<span class="field-label">Title</span>';
+      const titleInput = document.createElement('input');
+      titleInput.type = 'text';
+      titleInput.className = 'text-input';
+      titleInput.value = item.title;
+      titleInput.placeholder = 'e.g. Why it matters';
+      titleInput.addEventListener('input', () => {
+        working.items[index].title = titleInput.value;
+        emit(false);
+      });
+      titleField.append(titleInput);
+
+      const bodyField = document.createElement('label');
+      bodyField.className = 'field';
+      bodyField.innerHTML = '<span class="field-label">Body text</span>';
+      const bodyInput = document.createElement('textarea');
+      bodyInput.rows = 3;
+      bodyInput.value = item.body;
+      bodyInput.placeholder = 'Add the supporting explanation or prompt for this section.';
+      bodyInput.addEventListener('input', () => {
+        working.items[index].body = bodyInput.value;
+        emit(false);
+      });
+      bodyField.append(bodyInput);
+
+      editorItem.append(header, titleField, bodyField);
+      container.append(editorItem);
+    });
+
+    container.append(addButton);
+  };
+
+  rerender();
+};
+
+const renderPreview = (container, data, options = {}) => {
+  container.innerHTML = '';
+  const working = ensureWorkingState(data);
+  const playAnimations = options.playAnimations !== false;
+
+  if (!working.items.length) {
+    const empty = document.createElement('div');
+    empty.className = 'empty-state';
+    empty.innerHTML = '<p>Add accordion sections to see the preview.</p>';
+    container.append(empty);
+    return;
+  }
+
+  const wrapper = document.createElement('div');
+  wrapper.className = 'accordion';
+
+  const items = working.items.map((item, index) => {
+    const details = document.createElement('details');
+    details.className = 'accordion-item';
+    details.dataset.index = String(index);
+    if (index === 0) {
+      details.open = true;
+    }
+    if (playAnimations) {
+      details.classList.add('animate');
+      details.style.setProperty('--item-index', String(index));
+    }
+
+    const summary = document.createElement('summary');
+    summary.className = 'accordion-summary';
+
+    const title = document.createElement('span');
+    title.className = 'accordion-title';
+    title.textContent = typeof item.title === 'string' ? item.title : '';
+
+    const icon = document.createElement('span');
+    icon.className = 'accordion-icon';
+    icon.setAttribute('aria-hidden', 'true');
+
+    summary.append(title, icon);
+
+    const content = document.createElement('div');
+    content.className = 'accordion-content';
+    const body = document.createElement('div');
+    body.className = 'accordion-body';
+    body.textContent = typeof item.body === 'string' ? item.body : '';
+    content.append(body);
+
+    details.append(summary, content);
+    wrapper.append(details);
+    return details;
+  });
+
+  wrapper.addEventListener('toggle', (event) => {
+    const target = event.target;
+    if (!target || target.tagName !== 'DETAILS' || !target.open) {
+      return;
+    }
+    items.forEach((item) => {
+      if (item !== target) {
+        item.open = false;
+      }
+    });
+  });
+
+  container.append(wrapper);
+};
+
+const embedTemplate = (data, containerId) => {
+  const working = ensureWorkingState(data);
+  const items = working.items.length ? working.items : createSampleItems();
+  return {
+    html: `
+    <div class="cd-accordion">
+      ${items
+        .map(
+          (item, index) => `
+        <details class="cd-accordion-item animate" ${index === 0 ? 'open' : ''}>
+          <summary class="cd-accordion-summary">
+            <span class="cd-accordion-title">${
+              typeof item.title === 'string' ? escapeHtml(item.title) : ''
+            }</span>
+            <span class="cd-accordion-icon" aria-hidden="true"></span>
+          </summary>
+          <div class="cd-accordion-content">
+            <div class="cd-accordion-body">${
+              typeof item.body === 'string' ? escapeHtml(item.body) : ''
+            }</div>
+          </div>
+        </details>`
+        )
+        .join('')}
+    </div>
+  `,
+    css: `
+    #${containerId} .cd-accordion {
+      display: flex;
+      flex-direction: column;
+      gap: 0.8rem;
+    }
+    #${containerId} .cd-accordion-item {
+      border-radius: 16px;
+      border: 1px solid rgba(99, 102, 241, 0.15);
+      background: linear-gradient(135deg, rgba(255, 255, 255, 0.95), rgba(248, 250, 252, 0.9));
+      box-shadow: 0 18px 38px rgba(15, 23, 42, 0.12);
+      overflow: hidden;
+      transition: box-shadow 200ms ease, border-color 200ms ease;
+    }
+    #${containerId} .cd-accordion-item[open] {
+      border-color: rgba(99, 102, 241, 0.35);
+      box-shadow: 0 20px 44px rgba(99, 102, 241, 0.18);
+    }
+    #${containerId} .cd-accordion-summary {
+      position: relative;
+      list-style: none;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 1.2rem;
+      padding: 1.1rem 1.4rem;
+      font-weight: 600;
+      font-size: 1rem;
+      cursor: pointer;
+    }
+    #${containerId} .cd-accordion-summary::-webkit-details-marker {
+      display: none;
+    }
+    #${containerId} .cd-accordion-title {
+      flex: 1;
+      min-width: 0;
+    }
+    #${containerId} .cd-accordion-icon {
+      width: 2rem;
+      height: 2rem;
+      border-radius: 999px;
+      background: rgba(99, 102, 241, 0.12);
+      color: #6366f1;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      transition: transform 220ms ease;
+    }
+    #${containerId} .cd-accordion-icon::before {
+      content: '';
+      width: 10px;
+      height: 10px;
+      border: 2px solid currentColor;
+      border-top: 0;
+      border-right: 0;
+      transform: rotate(-45deg);
+      margin-top: -2px;
+    }
+    #${containerId} .cd-accordion-item[open] .cd-accordion-icon {
+      transform: rotate(180deg);
+    }
+    #${containerId} .cd-accordion-content {
+      padding: 0 1.4rem 1.2rem;
+      color: rgba(15, 23, 42, 0.8);
+      font-size: 0.95rem;
+    }
+    #${containerId} .cd-accordion-body {
+      margin: 0;
+      white-space: pre-wrap;
+      line-height: 1.55;
+    }
+    #${containerId} .cd-accordion-item.animate {
+      animation: cd-accordion-reveal 420ms cubic-bezier(0.22, 0.61, 0.36, 1) both;
+      animation-delay: calc(var(--item-index, 0) * 90ms);
+    }
+    @keyframes cd-accordion-reveal {
+      from {
+        opacity: 0;
+        transform: translateY(10px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+  `,
+    js: `
+    (function(){
+      const root = document.getElementById('${containerId}');
+      if (!root) return;
+      const items = Array.from(root.querySelectorAll('.cd-accordion-item'));
+      items.forEach((item) => {
+        item.addEventListener('toggle', () => {
+          if (!item.open) {
+            return;
+          }
+          item.classList.remove('animate');
+          items.forEach((other) => {
+            if (other !== item) {
+              other.removeAttribute('open');
+            }
+          });
+        });
+      });
+    })();
+  `
+  };
+};
+
+export const accordion = {
+  id: 'accordion',
+  label: 'Accordion',
+  template,
+  example,
+  buildEditor,
+  renderPreview,
+  embedTemplate
+};

--- a/docs/assets/js/activities/flipCards.js
+++ b/docs/assets/js/activities/flipCards.js
@@ -467,7 +467,8 @@ const renderPreview = (container, data, options = {}) => {
       const textWrapper = document.createElement('div');
       textWrapper.className = 'flipcard-face-content';
       const paragraph = document.createElement('p');
-      paragraph.textContent = card[faceKey] || fallbackText;
+      const value = card[faceKey];
+      paragraph.textContent = typeof value === 'string' ? value : fallbackText;
       textWrapper.append(paragraph);
       face.append(textWrapper);
       return face;
@@ -540,13 +541,17 @@ const embedTemplate = (data, containerId) => {
                 card.frontColor || DEFAULT_FRONT_COLORS[(useSyncedColors ? 0 : index) % DEFAULT_FRONT_COLORS.length]
               )};">
                 ${card.frontImage ? `<img src="${escapeHtml(card.frontImage)}" alt="" />` : ''}
-                <div class="cd-flipcard-face-content"><p>${escapeHtml(card.front || 'Front')}</p></div>
+                <div class="cd-flipcard-face-content"><p>${
+                  typeof card.front === 'string' ? escapeHtml(card.front) : 'Front'
+                }</p></div>
               </div>
               <div class="cd-flipcard-face cd-flipcard-back${card.backImage ? ' has-image' : ''}" style="background: ${escapeHtml(
                 card.backColor || DEFAULT_BACK_COLOR
               )};">
                 ${card.backImage ? `<img src="${escapeHtml(card.backImage)}" alt="" />` : ''}
-                <div class="cd-flipcard-face-content"><p>${escapeHtml(card.back || 'Back')}</p></div>
+                <div class="cd-flipcard-face-content"><p>${
+                  typeof card.back === 'string' ? escapeHtml(card.back) : 'Back'
+                }</p></div>
               </div>
             </div>
           </div>`
@@ -576,7 +581,7 @@ const embedTemplate = (data, containerId) => {
       min-height: 160px;
     }
     #${containerId} .cd-flipcard-inner.animate {
-      animation: cd-pulse-card 12s ease-in-out infinite;
+      animation: cd-flipcard-preview 1.1s cubic-bezier(0.22, 0.61, 0.36, 1) both;
     }
     #${containerId} .cd-flipcard.flipped .cd-flipcard-inner {
       transform: rotateY(180deg);
@@ -653,13 +658,18 @@ const embedTemplate = (data, containerId) => {
         transform: translateY(0) scale(1);
       }
     }
-    @keyframes cd-pulse-card {
-      0%,
-      100% {
-        transform: translateY(0);
+    @keyframes cd-flipcard-preview {
+      0% {
+        transform: rotateY(0deg);
       }
-      50% {
-        transform: translateY(-6px);
+      45% {
+        transform: rotateY(180deg);
+      }
+      55% {
+        transform: rotateY(180deg);
+      }
+      100% {
+        transform: rotateY(0deg);
       }
     }
   `,

--- a/docs/assets/js/activities/index.js
+++ b/docs/assets/js/activities/index.js
@@ -1,11 +1,15 @@
 import { flipCards } from './flipCards.js';
 import { dragDrop } from './dragDrop.js';
 import { hotspots } from './hotspots.js';
+import { accordion } from './accordion.js';
+import { timeline } from './timeline.js';
 
 export const activities = {
   [flipCards.id]: flipCards,
   [dragDrop.id]: dragDrop,
-  [hotspots.id]: hotspots
+  [hotspots.id]: hotspots,
+  [accordion.id]: accordion,
+  [timeline.id]: timeline
 };
 
 export const defaultActivityId = flipCards.id;

--- a/docs/assets/js/activities/timeline.js
+++ b/docs/assets/js/activities/timeline.js
@@ -1,0 +1,409 @@
+import { clone, uid, escapeHtml } from '../utils.js';
+
+const DEFAULT_ACCENT = '#6366f1';
+
+const createEvent = (overrides = {}, index = 0) => {
+  const base = {
+    id: uid('timeline-event'),
+    title: `Milestone ${index + 1}`,
+    date: '',
+    description: 'Describe what happens during this moment.'
+  };
+  const event = { ...base, ...overrides };
+  if (!event.id) {
+    event.id = uid('timeline-event');
+  }
+  if (typeof event.title !== 'string') {
+    event.title = '';
+  }
+  if (typeof event.date !== 'string') {
+    event.date = '';
+  }
+  if (typeof event.description !== 'string') {
+    event.description = '';
+  }
+  return event;
+};
+
+const normaliseEvents = (events) => {
+  if (!Array.isArray(events)) {
+    return [];
+  }
+  return events.map((event, index) => createEvent(event, index));
+};
+
+const createSampleEvents = () =>
+  normaliseEvents([
+    {
+      title: 'Kickoff',
+      date: 'Week 1',
+      description: 'Introduce the project, form teams, and clarify success criteria.'
+    },
+    {
+      title: 'Research',
+      date: 'Weeks 2-3',
+      description: 'Gather sources, conduct interviews, and capture findings in the shared notebook.'
+    },
+    {
+      title: 'Prototype + feedback',
+      date: 'Week 4',
+      description: 'Build a rough draft, collect peer feedback, and iterate before the final submission.'
+    }
+  ]);
+
+const template = () => ({
+  accentColor: DEFAULT_ACCENT,
+  events: createSampleEvents()
+});
+
+const example = () => ({
+  accentColor: '#0ea5e9',
+  events: normaliseEvents([
+    {
+      title: 'Question launched',
+      date: 'Monday',
+      description: 'Students review the driving question and brainstorm what they already know.'
+    },
+    {
+      title: 'Investigation',
+      date: 'Tuesday – Wednesday',
+      description: 'Teams collect evidence from labs, readings, or field work to answer the question.'
+    },
+    {
+      title: 'Synthesis',
+      date: 'Thursday',
+      description: 'Groups organise findings into a story or argument using the evidence they gathered.'
+    },
+    {
+      title: 'Showcase',
+      date: 'Friday',
+      description: 'Learners present their conclusions and reflect on new questions that emerged.'
+    }
+  ])
+});
+
+const ensureWorkingState = (data) => {
+  const safe = data ? clone(data) : {};
+  const accent =
+    typeof safe.accentColor === 'string' && safe.accentColor.trim() ? safe.accentColor.trim() : DEFAULT_ACCENT;
+  return {
+    accentColor: accent,
+    events: normaliseEvents(safe.events)
+  };
+};
+
+const buildEditor = (container, data, onUpdate) => {
+  const working = ensureWorkingState(data);
+
+  const emit = (refresh = true) => {
+    onUpdate(clone(working));
+    if (refresh) {
+      rerender();
+    }
+  };
+
+  const rerender = () => {
+    container.innerHTML = '';
+
+    const appearanceItem = document.createElement('div');
+    appearanceItem.className = 'editor-item';
+    const appearanceField = document.createElement('label');
+    appearanceField.className = 'field';
+    appearanceField.innerHTML = '<span class="field-label">Accent color</span>';
+    const colorInput = document.createElement('input');
+    colorInput.type = 'color';
+    colorInput.className = 'color-input';
+    colorInput.value = working.accentColor;
+    colorInput.addEventListener('input', () => {
+      working.accentColor = colorInput.value;
+      emit(false);
+    });
+    appearanceField.append(colorInput);
+    appearanceItem.append(appearanceField);
+    container.append(appearanceItem);
+
+    const addButton = document.createElement('button');
+    addButton.type = 'button';
+    addButton.className = 'ghost-button';
+    addButton.textContent = 'Add event';
+    addButton.addEventListener('click', () => {
+      working.events.push(createEvent({ title: 'New milestone', description: '' }, working.events.length));
+      emit();
+    });
+
+    if (!working.events.length) {
+      const empty = document.createElement('div');
+      empty.className = 'empty-state';
+      empty.innerHTML = '<p>No timeline events yet. Click “Add event” to create one.</p>';
+      container.append(empty);
+    }
+
+    working.events.forEach((event, index) => {
+      const editorItem = document.createElement('div');
+      editorItem.className = 'editor-item';
+
+      const header = document.createElement('div');
+      header.className = 'editor-item-header';
+      header.innerHTML = `<span>Event ${index + 1}</span>`;
+
+      const actions = document.createElement('div');
+      actions.className = 'editor-item-actions';
+
+      const duplicateBtn = document.createElement('button');
+      duplicateBtn.type = 'button';
+      duplicateBtn.className = 'muted-button';
+      duplicateBtn.textContent = 'Duplicate';
+      duplicateBtn.addEventListener('click', () => {
+        const cloneSource = clone(event);
+        working.events.splice(index + 1, 0, createEvent({ ...cloneSource, id: uid('timeline-event') }, index + 1));
+        emit();
+      });
+
+      const deleteBtn = document.createElement('button');
+      deleteBtn.type = 'button';
+      deleteBtn.className = 'muted-button';
+      deleteBtn.textContent = 'Remove';
+      deleteBtn.addEventListener('click', () => {
+        working.events.splice(index, 1);
+        emit();
+      });
+
+      actions.append(duplicateBtn, deleteBtn);
+      header.append(actions);
+
+      const titleField = document.createElement('label');
+      titleField.className = 'field';
+      titleField.innerHTML = '<span class="field-label">Title</span>';
+      const titleInput = document.createElement('input');
+      titleInput.type = 'text';
+      titleInput.className = 'text-input';
+      titleInput.value = event.title;
+      titleInput.placeholder = 'e.g. Draft submission';
+      titleInput.addEventListener('input', () => {
+        working.events[index].title = titleInput.value;
+        emit(false);
+      });
+      titleField.append(titleInput);
+
+      const dateField = document.createElement('label');
+      dateField.className = 'field';
+      dateField.innerHTML = '<span class="field-label">Date or label (optional)</span>';
+      const dateInput = document.createElement('input');
+      dateInput.type = 'text';
+      dateInput.className = 'text-input';
+      dateInput.value = event.date;
+      dateInput.placeholder = 'e.g. Week 2 or 14 Sept';
+      dateInput.addEventListener('input', () => {
+        working.events[index].date = dateInput.value;
+        emit(false);
+      });
+      dateField.append(dateInput);
+
+      const descriptionField = document.createElement('label');
+      descriptionField.className = 'field';
+      descriptionField.innerHTML = '<span class="field-label">Description</span>';
+      const descriptionInput = document.createElement('textarea');
+      descriptionInput.rows = 3;
+      descriptionInput.value = event.description;
+      descriptionInput.placeholder = 'Summarise the key tasks, resources, or goals for this event.';
+      descriptionInput.addEventListener('input', () => {
+        working.events[index].description = descriptionInput.value;
+        emit(false);
+      });
+      descriptionField.append(descriptionInput);
+
+      editorItem.append(header, titleField, dateField, descriptionField);
+      container.append(editorItem);
+    });
+
+    container.append(addButton);
+  };
+
+  rerender();
+};
+
+const renderPreview = (container, data, options = {}) => {
+  container.innerHTML = '';
+  const working = ensureWorkingState(data);
+  const playAnimations = options.playAnimations !== false;
+
+  if (!working.events.length) {
+    const empty = document.createElement('div');
+    empty.className = 'empty-state';
+    empty.innerHTML = '<p>Add timeline events to see the preview.</p>';
+    container.append(empty);
+    return;
+  }
+
+  const accent = working.accentColor || DEFAULT_ACCENT;
+  const wrapper = document.createElement('div');
+  wrapper.className = 'timeline';
+  wrapper.style.setProperty('--timeline-accent', accent);
+
+  working.events.forEach((event, index) => {
+    const item = document.createElement('div');
+    item.className = 'timeline-item';
+    if (playAnimations) {
+      item.classList.add('animate');
+      item.style.setProperty('--item-index', String(index));
+    }
+
+    const marker = document.createElement('div');
+    marker.className = 'timeline-marker';
+
+    const content = document.createElement('div');
+    content.className = 'timeline-content';
+
+    if (event.date) {
+      const date = document.createElement('span');
+      date.className = 'timeline-date';
+      date.textContent = event.date;
+      content.append(date);
+    }
+
+    const title = document.createElement('h3');
+    title.className = 'timeline-title';
+    title.textContent = event.title || '';
+    content.append(title);
+
+    if (event.description) {
+      const description = document.createElement('p');
+      description.className = 'timeline-description';
+      description.textContent = event.description;
+      content.append(description);
+    }
+
+    item.append(marker, content);
+    wrapper.append(item);
+  });
+
+  container.append(wrapper);
+};
+
+const embedTemplate = (data, containerId) => {
+  const working = ensureWorkingState(data);
+  const accent = working.accentColor || DEFAULT_ACCENT;
+  const events = working.events.length ? working.events : createSampleEvents();
+  return {
+    html: `
+    <div class="cd-timeline" style="--timeline-accent: ${escapeHtml(accent)};">
+      ${events
+        .map(
+          (event, index) => `
+        <div class="cd-timeline-item animate" style="--item-index: ${index};">
+          <div class="cd-timeline-marker"></div>
+          <div class="cd-timeline-content">
+            ${event.date ? `<span class="cd-timeline-date">${escapeHtml(event.date)}</span>` : ''}
+            <h3 class="cd-timeline-title">${
+              typeof event.title === 'string' ? escapeHtml(event.title) : ''
+            }</h3>
+            ${
+              event.description
+                ? `<p class="cd-timeline-description">${escapeHtml(event.description)}</p>`
+                : ''
+            }
+          </div>
+        </div>`
+        )
+        .join('')}
+    </div>
+  `,
+    css: `
+    #${containerId} .cd-timeline {
+      --timeline-accent: ${escapeHtml(accent)};
+      position: relative;
+      display: grid;
+      gap: 1.5rem;
+      padding-left: 1.6rem;
+    }
+    #${containerId} .cd-timeline::before {
+      content: '';
+      position: absolute;
+      left: 0.55rem;
+      top: 0.75rem;
+      bottom: 0.75rem;
+      width: 2px;
+      background: linear-gradient(180deg, rgba(99, 102, 241, 0.35), rgba(99, 102, 241, 0.05));
+    }
+    #${containerId} .cd-timeline-item {
+      position: relative;
+      display: grid;
+      grid-template-columns: min-content 1fr;
+      gap: 1.2rem;
+    }
+    #${containerId} .cd-timeline-item.animate {
+      animation: cd-timeline-reveal 460ms cubic-bezier(0.22, 0.61, 0.36, 1) both;
+      animation-delay: calc(var(--item-index, 0) * 110ms);
+    }
+    #${containerId} .cd-timeline-item::before {
+      content: '';
+      position: absolute;
+      left: 0.55rem;
+      top: 1.7rem;
+      bottom: -1.5rem;
+      width: 2px;
+      background: linear-gradient(180deg, rgba(148, 163, 184, 0.4), rgba(148, 163, 184, 0));
+    }
+    #${containerId} .cd-timeline-item:last-child::before {
+      display: none;
+    }
+    #${containerId} .cd-timeline-marker {
+      width: 1.15rem;
+      height: 1.15rem;
+      border-radius: 999px;
+      background: #ffffff;
+      border: 3px solid var(--timeline-accent);
+      box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.12);
+      margin-top: 0.4rem;
+    }
+    #${containerId} .cd-timeline-content {
+      background: rgba(255, 255, 255, 0.95);
+      border-radius: 16px;
+      padding: 1rem 1.3rem;
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      box-shadow: 0 16px 32px rgba(15, 23, 42, 0.14);
+    }
+    #${containerId} .cd-timeline-date {
+      display: inline-block;
+      font-size: 0.82rem;
+      font-weight: 600;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      color: var(--timeline-accent);
+      margin-bottom: 0.35rem;
+    }
+    #${containerId} .cd-timeline-title {
+      margin: 0;
+      font-size: 1.05rem;
+      color: #0f172a;
+    }
+    #${containerId} .cd-timeline-description {
+      margin: 0.45rem 0 0;
+      color: rgba(15, 23, 42, 0.78);
+      line-height: 1.6;
+      white-space: pre-wrap;
+    }
+    @keyframes cd-timeline-reveal {
+      from {
+        opacity: 0;
+        transform: translateY(12px);
+      }
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+  `,
+    js: ''
+  };
+};
+
+export const timeline = {
+  id: 'timeline',
+  label: 'Timeline',
+  template,
+  example,
+  buildEditor,
+  renderPreview,
+  embedTemplate
+};

--- a/index.html
+++ b/index.html
@@ -44,6 +44,8 @@
             <h2 class="panel-title">Choose an activity</h2>
             <div class="activity-selector" role="tablist">
               <button class="activity-tab" data-activity="flipCards" role="tab">Flip cards</button>
+              <button class="activity-tab" data-activity="accordion" role="tab">Accordion</button>
+              <button class="activity-tab" data-activity="timeline" role="tab">Timeline</button>
               <button class="activity-tab" data-activity="dragDrop" role="tab">Drag &amp; Drop</button>
               <button class="activity-tab" data-activity="hotspots" role="tab">Hotspots</button>
             </div>


### PR DESCRIPTION
## Summary
- update flip card rendering to allow blank faces and use a flip entrance animation
- introduce an accordion activity with editor controls, preview styling, and embed support
- add a timeline activity with accent color control and embed-ready markup/CSS

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d69d9302a8832b82121867fba44f61