### PR TITLE
Fix flip card interaction animation

### DIFF
--- a/assets/js/activities/flipCards.js
+++ b/assets/js/activities/flipCards.js
@@ -481,22 +481,22 @@ const renderPreview = (container, data, options = {}) => {
     inner.append(front, back);
     cardWrapper.append(inner);
 
+    let hasInteracted = false;
+
     const setFlipState = (flipped) => {
-      if (flipped) {
-        cardWrapper.classList.add('flipped');
-        if (playAnimations) {
-          inner.classList.remove('animate');
-        }
-      } else {
-        cardWrapper.classList.remove('flipped');
-        if (playAnimations) {
+      cardWrapper.classList.toggle('flipped', flipped);
+      if (playAnimations) {
+        if (!flipped && !hasInteracted) {
           inner.classList.add('animate');
+        } else {
+          inner.classList.remove('animate');
         }
       }
       cardWrapper.setAttribute('aria-pressed', flipped ? 'true' : 'false');
     };
 
     const toggleFlip = () => {
+      hasInteracted = true;
       const nextState = !cardWrapper.classList.contains('flipped');
       setFlipState(nextState);
     };
@@ -679,19 +679,21 @@ const embedTemplate = (data, containerId) => {
       if (!root) return;
       root.querySelectorAll('.cd-flipcard').forEach((card) => {
         const inner = card.querySelector('.cd-flipcard-inner');
+        let hasInteracted = false;
         const setState = (flipped) => {
           card.classList.toggle('flipped', flipped);
           if (inner) {
-            if (flipped) {
-              inner.classList.remove('animate');
-            } else {
+            if (!flipped && !hasInteracted) {
               inner.classList.add('animate');
+            } else {
+              inner.classList.remove('animate');
             }
           }
           card.setAttribute('aria-pressed', String(flipped));
         };
         setState(false);
         const toggle = () => {
+          hasInteracted = true;
           const nextState = !card.classList.contains('flipped');
           setState(nextState);
         };

--- a/docs/assets/js/activities/flipCards.js
+++ b/docs/assets/js/activities/flipCards.js
@@ -481,22 +481,22 @@ const renderPreview = (container, data, options = {}) => {
     inner.append(front, back);
     cardWrapper.append(inner);
 
+    let hasInteracted = false;
+
     const setFlipState = (flipped) => {
-      if (flipped) {
-        cardWrapper.classList.add('flipped');
-        if (playAnimations) {
-          inner.classList.remove('animate');
-        }
-      } else {
-        cardWrapper.classList.remove('flipped');
-        if (playAnimations) {
+      cardWrapper.classList.toggle('flipped', flipped);
+      if (playAnimations) {
+        if (!flipped && !hasInteracted) {
           inner.classList.add('animate');
+        } else {
+          inner.classList.remove('animate');
         }
       }
       cardWrapper.setAttribute('aria-pressed', flipped ? 'true' : 'false');
     };
 
     const toggleFlip = () => {
+      hasInteracted = true;
       const nextState = !cardWrapper.classList.contains('flipped');
       setFlipState(nextState);
     };
@@ -679,19 +679,21 @@ const embedTemplate = (data, containerId) => {
       if (!root) return;
       root.querySelectorAll('.cd-flipcard').forEach((card) => {
         const inner = card.querySelector('.cd-flipcard-inner');
+        let hasInteracted = false;
         const setState = (flipped) => {
           card.classList.toggle('flipped', flipped);
           if (inner) {
-            if (flipped) {
-              inner.classList.remove('animate');
-            } else {
+            if (!flipped && !hasInteracted) {
               inner.classList.add('animate');
+            } else {
+              inner.classList.remove('animate');
             }
           }
           card.setAttribute('aria-pressed', String(flipped));
         };
         setState(false);
         const toggle = () => {
+          hasInteracted = true;
           const nextState = !card.classList.contains('flipped');
           setState(nextState);
         };


### PR DESCRIPTION
## Summary
- ensure flip cards stop replaying the preview animation after the first user interaction
- update the embed template logic to keep flip state toggling consistent between preview and published output

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d6aeaf4258832b8446031579bb63d9