### PR TITLE
Improve flip card animation reliability and timeline reveals

### DIFF
--- a/assets/js/activities/flipCards.js
+++ b/assets/js/activities/flipCards.js
@@ -496,8 +496,12 @@ const renderPreview = (container, data, options = {}) => {
     };
 
     const toggleFlip = () => {
-      hasInteracted = true;
       const nextState = !cardWrapper.classList.contains('flipped');
+      if (playAnimations && inner.classList.contains('animate')) {
+        inner.classList.remove('animate');
+        void inner.offsetWidth;
+      }
+      hasInteracted = true;
       setFlipState(nextState);
     };
 
@@ -693,8 +697,12 @@ const embedTemplate = (data, containerId) => {
         };
         setState(false);
         const toggle = () => {
-          hasInteracted = true;
           const nextState = !card.classList.contains('flipped');
+          if (inner && inner.classList.contains('animate')) {
+            inner.classList.remove('animate');
+            void inner.offsetWidth;
+          }
+          hasInteracted = true;
           setState(nextState);
         };
         card.addEventListener('click', toggle);

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -850,6 +850,12 @@ textarea:focus {
   border: 3px solid var(--timeline-accent);
   box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.12);
   margin-top: 0.4rem;
+  transition: transform 220ms ease, box-shadow 220ms ease;
+}
+
+.timeline-item.is-active .timeline-marker {
+  transform: scale(1.05);
+  box-shadow: 0 0 0 6px rgba(99, 102, 241, 0.18);
 }
 
 .timeline-content {
@@ -858,6 +864,50 @@ textarea:focus {
   padding: 1rem 1.3rem;
   border: 1px solid rgba(148, 163, 184, 0.25);
   box-shadow: 0 16px 32px rgba(15, 23, 42, 0.14);
+  display: grid;
+  gap: 0.75rem;
+  transition: border-color 240ms ease, box-shadow 240ms ease;
+}
+
+.timeline-item.is-active .timeline-content {
+  border-color: rgba(99, 102, 241, 0.35);
+  box-shadow: 0 20px 36px rgba(15, 23, 42, 0.18);
+}
+
+.timeline-trigger {
+  width: 100%;
+  border: none;
+  background: transparent;
+  text-align: left;
+  padding: 0;
+  margin: 0;
+  font: inherit;
+  color: inherit;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  cursor: pointer;
+}
+
+.timeline-trigger:focus-visible {
+  outline: 2px solid var(--timeline-accent);
+  outline-offset: 4px;
+  border-radius: 12px;
+}
+
+.timeline-trigger--static {
+  cursor: default;
+}
+
+.timeline-trigger--static:focus-visible {
+  outline: none;
+}
+
+.timeline-trigger-text {
+  display: grid;
+  gap: 0.3rem;
+  flex: 1;
 }
 
 .timeline-date {
@@ -867,17 +917,52 @@ textarea:focus {
   letter-spacing: 0.05em;
   text-transform: uppercase;
   color: var(--timeline-accent);
-  margin-bottom: 0.35rem;
+  margin: 0;
 }
 
 .timeline-title {
   margin: 0;
   font-size: 1.05rem;
   color: #0f172a;
+  font-weight: 600;
+}
+
+.timeline-trigger-icon {
+  width: 1.6rem;
+  height: 1.6rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  background: rgba(99, 102, 241, 0.12);
+  color: var(--timeline-accent);
+  transition: transform 240ms ease, background-color 240ms ease, color 240ms ease;
+}
+
+.timeline-item.is-active .timeline-trigger-icon {
+  transform: rotate(180deg);
+  background: var(--timeline-accent);
+  color: #ffffff;
+}
+
+.timeline-details {
+  overflow: hidden;
+  max-height: 0;
+  opacity: 0;
+  transform: translateY(-6px);
+  border-top: 1px solid rgba(148, 163, 184, 0.25);
+  padding-top: 0.75rem;
+  transition: max-height 320ms cubic-bezier(0.22, 0.61, 0.36, 1), opacity 220ms ease, transform 220ms ease;
+}
+
+.timeline-item.is-active .timeline-details {
+  opacity: 1;
+  transform: translateY(0);
 }
 
 .timeline-description {
-  margin: 0.45rem 0 0;
+  margin: 0;
   color: rgba(15, 23, 42, 0.78);
   line-height: 1.6;
   white-space: pre-wrap;


### PR DESCRIPTION
## Summary
- ensure flip cards clear the preview animation before toggling so the first user click animates correctly
- rebuild the timeline preview and embed markup to reveal event details on click with animated expansion and keyboard-friendly triggers
- refresh timeline styles to support the new interactive layout

## Testing
- Manual Playwright run to capture updated timeline preview

------
https://chatgpt.com/codex/tasks/task_e_68d6b6295c14832b9c51b0966a5341a3