### PR TITLE
Make embed viewer backgrounds transparent

### DIFF
--- a/assets/js/embed.js
+++ b/assets/js/embed.js
@@ -162,7 +162,7 @@ export const generateEmbed = ({ id, type, title, description, data }) => {
   loading="lazy"
   referrerpolicy="no-referrer"
   sandbox="allow-scripts allow-same-origin"
-  style="width: 100%; min-height: 420px; border: 0; border-radius: 12px; overflow: hidden;"
+  style="width: 100%; min-height: 420px; border: 0; border-radius: 12px; overflow: hidden; background-color: transparent;"
   src="${viewerUrl.toString()}"
 ></iframe>
 <script type="text/javascript">

--- a/assets/js/embedViewer.js
+++ b/assets/js/embedViewer.js
@@ -9,6 +9,7 @@ const baseStyles = (containerId) => `
     line-height: 1.5;
     display: grid;
     gap: 1rem;
+    background: transparent;
   }
   #${containerId} *,
   #${containerId} *::before,

--- a/docs/assets/js/embedViewer.js
+++ b/docs/assets/js/embedViewer.js
@@ -17,6 +17,7 @@ const baseStyles = (containerId) => `
     line-height: 1.5;
     display: grid;
     gap: 1rem;
+    background: transparent;
   }
   #${containerId} *,
   #${containerId} *::before,

--- a/docs/embed.html
+++ b/docs/embed.html
@@ -19,22 +19,24 @@
       *::after {
         box-sizing: border-box;
       }
+      html,
+      body {
+        background: transparent;
+      }
       body {
         margin: 0;
         min-height: 100vh;
         font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-        background: #f8fafc;
         color: #0f172a;
-        display: flex;
-        justify-content: center;
-        padding: 2.5rem 1.5rem;
+        padding: clamp(1rem, 2vw + 0.5rem, 2rem);
       }
       .cd-embed-viewer-shell {
         width: min(960px, 100%);
-        background: #ffffff;
-        border-radius: 20px;
-        padding: clamp(1.5rem, 2vw + 1rem, 2.5rem);
-        box-shadow: 0 24px 48px rgba(15, 23, 42, 0.12);
+        margin: 0 auto;
+        background: transparent;
+        border-radius: 0;
+        padding: 0;
+        box-shadow: none;
       }
       .cd-viewer-message {
         padding: 1.25rem;


### PR DESCRIPTION
## Summary
- remove the white shell from the embed viewer HTML so Canvas pages show through
- ensure the generated iframe and runtime styles explicitly use transparent backgrounds across activities

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d71b1c0230832bb42b4e010da10e04