### PR TITLE
Ensure flipcards collapse to single column on small screens

### DIFF
--- a/assets/js/activities/flipCards.js
+++ b/assets/js/activities/flipCards.js
@@ -568,6 +568,11 @@ const embedTemplate = (data, containerId) => {
       display: grid;
       gap: 1.2rem;
     }
+    @media (max-width: 640px) {
+      #${containerId} .cd-flipcard-grid {
+        grid-template-columns: 1fr !important;
+      }
+    }
     #${containerId} .cd-flipcard {
       perspective: 1000px;
       cursor: pointer;

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -1547,7 +1547,7 @@ textarea:focus {
 @media (max-width: 640px) {
   .flipcard-grid {
     gap: 16px;
-    grid-template-columns: 1fr;
+    grid-template-columns: 1fr !important;
   }
 
   .flipcard-inner {

--- a/docs/assets/js/activities/flipCards.js
+++ b/docs/assets/js/activities/flipCards.js
@@ -564,6 +564,11 @@ const embedTemplate = (data, containerId) => {
       display: grid;
       gap: 1.2rem;
     }
+    @media (max-width: 640px) {
+      #${containerId} .cd-flipcard-grid {
+        grid-template-columns: 1fr !important;
+      }
+    }
     #${containerId} .cd-flipcard {
       perspective: 1000px;
       cursor: pointer;


### PR DESCRIPTION
## Summary
- force flip card grids to a single column on narrow viewports in the editor stylesheet
- ensure embedded flip card activities override column counts on small screens
- mirror the responsive override in the published documentation bundle

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d72d4b55c0832bb5ad642c0617e90d