### PR TITLE
Fix flip card faces overlapping on Safari

### DIFF
--- a/assets/js/activities/flipCards.js
+++ b/assets/js/activities/flipCards.js
@@ -586,6 +586,7 @@ const embedTemplate = (data, containerId) => {
       position: relative;
       width: 100%;
       transform-style: preserve-3d;
+      -webkit-transform-style: preserve-3d;
       transition: transform 0.6s cubic-bezier(0.22, 0.61, 0.36, 1);
       min-height: 160px;
     }
@@ -604,6 +605,7 @@ const embedTemplate = (data, containerId) => {
       position: absolute;
       inset: 0;
       backface-visibility: hidden;
+      -webkit-backface-visibility: hidden;
       border-radius: 14px;
       padding: 1.2rem;
       display: flex;

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -596,6 +596,7 @@ textarea:focus {
   position: relative;
   width: 100%;
   transform-style: preserve-3d;
+  -webkit-transform-style: preserve-3d;
   transition: transform 0.6s cubic-bezier(0.22, 0.61, 0.36, 1);
   min-height: 180px;
 }
@@ -643,6 +644,7 @@ textarea:focus {
   position: absolute;
   inset: 0;
   backface-visibility: hidden;
+  -webkit-backface-visibility: hidden;
   border-radius: 16px;
   padding: 1.4rem;
   display: flex;


### PR DESCRIPTION
## Summary
- add WebKit transform-style/backface visibility prefixes to flip card styles in the builder
- mirror the Safari-specific fixes in the generated embed CSS so published cards render correctly

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d7384bf7cc832bbd0e1e0677646bdc