### PR TITLE
Collapse immersive text details until marker activation

### DIFF
--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -1646,12 +1646,22 @@ textarea:focus {
   flex-direction: column;
   gap: 0.8rem;
   min-height: 240px;
+  justify-content: center;
+}
+
+.cd-immersive-panel--active {
+  justify-content: flex-start;
 }
 
 .cd-immersive-detail {
   display: flex;
   flex-direction: column;
   gap: 0.8rem;
+}
+
+.cd-immersive-detail--enter,
+.cd-immersive-empty--enter {
+  animation: cd-immersive-detail-in 240ms cubic-bezier(0.22, 0.61, 0.36, 1) both;
 }
 
 .cd-immersive-detail-title {
@@ -1701,6 +1711,17 @@ textarea:focus {
   border-color: rgba(14, 165, 233, 0.55);
   box-shadow: 0 14px 28px rgba(14, 165, 233, 0.22);
   transform: translateY(-1px);
+}
+
+@keyframes cd-immersive-detail-in {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .cd-immersive-quiz-option.is-correct {


### PR DESCRIPTION
## Summary
- prevent immersive text panels from auto-opening so highlights stay collapsed until selected
- add toggled marker handling and animated detail entry for notes and quizzes
- style the immersive panel to center its prompt and animate content on reveal

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d73a0c4524832b98f0e5d9ee5f70f8