### PR TITLE
Add per-activity learning tip toggle

### DIFF
--- a/assets/js/activities/accordion.js
+++ b/assets/js/activities/accordion.js
@@ -372,6 +372,21 @@ const embedTemplate = (data, containerId) => {
   };
 };
 
+const learningTip = {
+  intro: 'Accordions break dense information into digestible bites while letting learners control the pace.',
+  when: 'Use them to structure multi-step processes, FAQs, or concept comparisons where learners may explore sections in any order.',
+  considerations: [
+    'Write headings that read like summary statements so skim readers grasp the key idea before expanding.',
+    'Balance the amount of media and text in each pane so no single section feels overwhelming.',
+    'Layer in prompts, visuals, or follow-up questions inside panels to keep learners actively processing what they open.'
+  ],
+  examples: [
+    'Course orientation: present syllabus highlights, grading policies, and support resources as expandable sections.',
+    'Lab protocol: outline each experiment phase with embedded safety reminders in the relevant pane.',
+    'Case study debrief: reveal context, evidence, and instructor analysis one panel at a time.'
+  ]
+};
+
 export const accordion = {
   id: 'accordion',
   label: 'Accordion',
@@ -379,5 +394,6 @@ export const accordion = {
   example,
   buildEditor,
   renderPreview,
-  embedTemplate
+  embedTemplate,
+  learningTip
 };

--- a/assets/js/activities/branchingScenarios.js
+++ b/assets/js/activities/branchingScenarios.js
@@ -638,6 +638,21 @@ const embedTemplate = (data, containerId) => {
   return { html, css, js };
 };
 
+const learningTip = {
+  intro: 'Branching scenarios let learners practise complex judgement calls in a safe, feedback-rich sandbox.',
+  when: 'Use them for conversations, ethical dilemmas, or procedural decisions where the reasoning path matters as much as the final answer.',
+  considerations: [
+    'Anchor each scene in a realistic context with dialogue and cues your learners would actually encounter.',
+    'Sketch the decision tree first and keep it manageable—three to four key decision points usually provide enough depth without overwhelming authors or learners.',
+    'Deliver feedback or reflection prompts after every choice so learners connect their decision to its impact.'
+  ],
+  examples: [
+    'Customer service coaching: guide a representative through de-escalating an upset client.',
+    'Clinical reasoning drill: select assessments and interventions for a patient with evolving symptoms.',
+    'Academic integrity lesson: explore responses when a peer shares unauthorized materials and evaluate consequences.'
+  ]
+};
+
 export const branchingScenarios = {
   id: 'branchingScenarios',
   label: 'Branching scenarios',
@@ -645,5 +660,6 @@ export const branchingScenarios = {
   example,
   buildEditor,
   renderPreview,
-  embedTemplate
+  embedTemplate,
+  learningTip
 };

--- a/assets/js/activities/dragDrop.js
+++ b/assets/js/activities/dragDrop.js
@@ -946,6 +946,21 @@ const embedTemplate = (data, containerId) => {
   };
 };
 
+const learningTip = {
+  intro: 'Drag & drop matchers turn recall into an active puzzle so learners can test their understanding before high-stakes assessments.',
+  when: 'Use them when learners need to connect pairs, build sequences, or sort concepts and will benefit from immediate, low-risk feedback.',
+  considerations: [
+    'Keep instructions explicit and limit the total number of draggable items so the task stays focused.',
+    'Include plausible distractors, but avoid trick options that rely on tiny wording differences.',
+    'Confirm keyboard alternatives are clear and add a reflective prompt or explanation when learners check their work.'
+  ],
+  examples: [
+    'Vocabulary clinic: match academic terms to real-world scenarios they describe.',
+    'Anatomy lab: drag structure labels onto the correct location on a diagram.',
+    'Project management sprint: pair deliverables with the stakeholder accountable for each one.'
+  ]
+};
+
 export const dragDrop = {
   id: 'dragDrop',
   label: 'Drag & Drop',
@@ -953,6 +968,7 @@ export const dragDrop = {
   example,
   buildEditor,
   renderPreview,
-  embedTemplate
+  embedTemplate,
+  learningTip
 };
 

--- a/assets/js/activities/flipCards.js
+++ b/assets/js/activities/flipCards.js
@@ -725,6 +725,21 @@ const embedTemplate = (data, containerId) => {
   };
 };
 
+const learningTip = {
+  intro: 'Flip cards create quick retrieval practice loops that strengthen recall through repetition.',
+  when: 'Use them for rapid-fire review of vocabulary, processes, or paired concepts where learners benefit from self-checking.',
+  considerations: [
+    'Keep prompts and answers concise so flipping feels quick and confidence-building.',
+    'Group related cards into focused sets (6–8 works well) to prevent cognitive overload.',
+    'Mix representations—text, icons, or simple images—to deepen retrieval cues.'
+  ],
+  examples: [
+    'Language learning: match academic vocabulary to plain-language definitions.',
+    'STEM refresher: pair formulas with everyday scenarios that require them.',
+    'Nursing prep: flip between patient symptoms and likely underlying conditions.'
+  ]
+};
+
 export const flipCards = {
   id: 'flipCards',
   label: 'Flip cards',
@@ -732,5 +747,6 @@ export const flipCards = {
   example,
   buildEditor,
   renderPreview,
-  embedTemplate
+  embedTemplate,
+  learningTip
 };

--- a/assets/js/activities/hotspots.js
+++ b/assets/js/activities/hotspots.js
@@ -580,6 +580,21 @@ const embedTemplate = (data, containerId) => ({
   `
 });
 
+const learningTip = {
+  intro: 'Hotspots invite learners to explore an image and reveal layered context right where it appears.',
+  when: 'Use them when spatial relationships or visual cues matter—maps, lab setups, artworks, equipment layouts, or complex diagrams.',
+  considerations: [
+    'Select a high-resolution image and crop thoughtfully so every marker area stays clear on different screens.',
+    'Write concise titles and offer descriptive text or transcripts so screen reader users can access the same insights.',
+    'Provide a guiding question or suggested sequence if you need learners to follow a particular narrative through the hotspots.'
+  ],
+  examples: [
+    'Geography module: annotate a regional map with climate impacts and local data stories.',
+    'Studio art critique: highlight composition choices directly on a student artwork.',
+    'STEM safety briefing: point out critical instruments and protective gear on a lab bench.'
+  ]
+};
+
 export const hotspots = {
   id: 'hotspots',
   label: 'Hotspots',
@@ -587,5 +602,6 @@ export const hotspots = {
   example,
   buildEditor,
   renderPreview,
-  embedTemplate
+  embedTemplate,
+  learningTip
 };

--- a/assets/js/activities/imageCarousel.js
+++ b/assets/js/activities/imageCarousel.js
@@ -622,6 +622,21 @@ const embedTemplate = (data, containerId) => {
   return { html, css, js };
 };
 
+const learningTip = {
+  intro: 'Image carousels curate a guided gallery so learners can focus on one visual story beat at a time.',
+  when: 'Use them to compare variations, walk through a visual process, or showcase exemplars when the imagery carries the main insight.',
+  considerations: [
+    'Sequence slides intentionally and write concise captions that spotlight what to notice in each frame.',
+    'Limit the deck to a manageable set—around four to six images keeps learners oriented and avoids fatigue.',
+    'Provide descriptive alt text or a companion transcript so every learner can access the full narrative.'
+  ],
+  examples: [
+    'Art history spotlight: contrast interpretations of the same theme with curator commentary per slide.',
+    'Science lab prep: illustrate stages of an experiment alongside safety reminders and setup tips.',
+    'Design critique: show before-and-after iterations of a prototype with notes on design decisions.'
+  ]
+};
+
 export const imageCarousel = {
   id: 'imageCarousel',
   label: 'Image carousel',
@@ -629,5 +644,6 @@ export const imageCarousel = {
   example,
   buildEditor,
   renderPreview,
-  embedTemplate
+  embedTemplate,
+  learningTip
 };

--- a/assets/js/activities/immersiveText.js
+++ b/assets/js/activities/immersiveText.js
@@ -1171,6 +1171,21 @@ const buildAnnotatedFragmentHtml = (body, annotations) => {
   return html;
 };
 
+const learningTip = {
+  intro: 'Immersive text overlays slow readers down in the best way—pairing a passage with prompts, annotations, and micro-checks.',
+  when: 'Use them for close reading, walkthroughs of complex explanations, or primary sources where you want to model expert thinking in context.',
+  considerations: [
+    'Highlight only the most essential excerpts so the page does not feel crowded with markers.',
+    'Sequence annotations to scaffold thinking—from noticing, to interpreting, to applying the idea elsewhere.',
+    'Mix interaction types (comments, guiding questions, quick quizzes) to keep engagement active and varied.'
+  ],
+  examples: [
+    'Literature seminar: annotate a poem with historical context and reflection prompts.',
+    'Business case study: surface decision checkpoints with data callouts and “what would you do?” questions.',
+    'STEM reading: insert micro-quizzes beside procedural steps to confirm understanding before moving on.'
+  ]
+};
+
 export const immersiveText = {
   id: 'immersiveText',
   label: 'Immersive text',
@@ -1178,5 +1193,6 @@ export const immersiveText = {
   example,
   buildEditor,
   renderPreview,
-  embedTemplate
+  embedTemplate,
+  learningTip
 };

--- a/assets/js/activities/timeline.js
+++ b/assets/js/activities/timeline.js
@@ -641,6 +641,21 @@ const embedTemplate = (data, containerId) => {
   };
 };
 
+const learningTip = {
+  intro: 'Timelines help learners visualise sequences, dependencies, and momentum across a story or process.',
+  when: 'Use them when chronology or progression matters—showing how milestones build on one another or how parallel events connect.',
+  considerations: [
+    'Keep event titles concise and descriptive so the flow of the story is easy to scan.',
+    'Choose a consistent level of date granularity and trim any timestamps that do not advance the narrative.',
+    'Call out pivotal transitions with brief annotations, icons, or media so turning points stand out.'
+  ],
+  examples: [
+    'History seminar: trace the key milestones that led to a social movement or policy shift.',
+    'Health sciences: map a patient case from triage to discharge with decision points highlighted.',
+    'Business course: chart a product release roadmap alongside major customer insights.'
+  ]
+};
+
 export const timeline = {
   id: 'timeline',
   label: 'Timeline',
@@ -648,5 +663,6 @@ export const timeline = {
   example,
   buildEditor,
   renderPreview,
-  embedTemplate
+  embedTemplate,
+  learningTip
 };

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -239,6 +239,123 @@ body.modal-open {
   gap: 12px;
 }
 
+.panel-header--tips {
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 14px;
+}
+
+.panel-header--tips .panel-title {
+  flex: 1 1 auto;
+}
+
+.tip-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  border: none;
+  border-radius: 999px;
+  padding: 10px 18px;
+  background: linear-gradient(135deg, #fde68a, #f97316);
+  color: #0f172a;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  box-shadow: 0 18px 32px rgba(249, 115, 22, 0.28);
+  transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
+}
+
+.tip-toggle:hover,
+.tip-toggle:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 22px 40px rgba(249, 115, 22, 0.35);
+}
+
+.tip-toggle:focus-visible {
+  outline: none;
+  background: linear-gradient(135deg, #fef3c7, #fb923c);
+}
+
+.tip-toggle[aria-expanded='true'] {
+  background: linear-gradient(135deg, #fef08a, #f59e0b);
+}
+
+.tip-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.32);
+  font-size: 1.1rem;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.4);
+}
+
+.tip-label {
+  white-space: nowrap;
+}
+
+.activity-tip {
+  margin-top: 4px;
+  padding: 18px 20px;
+  border-radius: var(--radius);
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.92), rgba(254, 249, 195, 0.9));
+  border: 1px solid rgba(249, 115, 22, 0.18);
+  box-shadow: 0 20px 44px rgba(15, 23, 42, 0.12);
+  color: var(--text);
+}
+
+.activity-tip-title {
+  margin: 0 0 6px;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.activity-tip-intro {
+  margin: 0 0 12px;
+  font-size: 0.9rem;
+  color: var(--text);
+}
+
+.activity-tip-section {
+  margin-top: 12px;
+}
+
+.activity-tip-section:first-of-type {
+  margin-top: 0;
+}
+
+.activity-tip-heading {
+  margin: 0 0 6px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.8);
+}
+
+.activity-tip-body {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.45;
+  color: var(--text);
+}
+
+.activity-tip-list {
+  margin: 0;
+  padding-left: 18px;
+  font-size: 0.9rem;
+  color: var(--text);
+}
+
+.activity-tip-list li {
+  margin-bottom: 6px;
+  line-height: 1.45;
+}
+
+.activity-tip-list li:last-child {
+  margin-bottom: 0;
+}
+
 .panel-buttons {
   display: flex;
   gap: 8px;

--- a/index.html
+++ b/index.html
@@ -41,8 +41,42 @@
       <main class="app-main">
         <aside class="control-panel" aria-label="Activity configuration">
           <section class="panel-block">
-            <h2 class="panel-title">Choose an activity</h2>
-          <div class="activity-selector" role="tablist">
+            <div class="panel-header panel-header--tips">
+              <h2 class="panel-title">Choose an activity</h2>
+              <button
+                id="activityTipToggle"
+                class="tip-toggle"
+                type="button"
+                aria-expanded="false"
+                aria-controls="activityTipPanel"
+              >
+                <span class="tip-icon" aria-hidden="true">💡</span>
+                <span id="activityTipToggleLabel" class="tip-label">Show learning tips</span>
+              </button>
+            </div>
+            <div
+              id="activityTipPanel"
+              class="activity-tip"
+              hidden
+              role="region"
+              aria-live="polite"
+            >
+              <h3 id="activityTipTitle" class="activity-tip-title"></h3>
+              <p id="activityTipIntro" class="activity-tip-intro"></p>
+              <div id="activityTipWhenSection" class="activity-tip-section">
+                <h4 class="activity-tip-heading">When to use it</h4>
+                <p id="activityTipWhen" class="activity-tip-body"></p>
+              </div>
+              <div id="activityTipConsiderationsSection" class="activity-tip-section">
+                <h4 class="activity-tip-heading">Design considerations</h4>
+                <ul id="activityTipConsiderations" class="activity-tip-list"></ul>
+              </div>
+              <div id="activityTipExamplesSection" class="activity-tip-section">
+                <h4 class="activity-tip-heading">Quick examples</h4>
+                <ul id="activityTipExamples" class="activity-tip-list"></ul>
+              </div>
+            </div>
+            <div class="activity-selector" role="tablist">
             <button class="activity-tab" data-activity="flipCards" role="tab">Flip cards</button>
             <button class="activity-tab" data-activity="accordion" role="tab">Accordion</button>
             <button class="activity-tab" data-activity="timeline" role="tab">Timeline</button>


### PR DESCRIPTION
## Summary
- add a prominent lightbulb toggle that reveals activity-specific pedagogy tips in the activity picker
- populate learning design guidance for each activity, covering when to use it, key considerations, and quick examples
- update styling and app logic to manage the toggle state, dynamic copy, and accessibility labels

## Testing
- Manual QA: opened http://127.0.0.1:4173/index.html and toggled the learning tips

------
https://chatgpt.com/codex/tasks/task_e_68d742da7f54832ba08e7a03379a836a