### PR TITLE
Add dropdown activity picker

### DIFF
--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -373,33 +373,73 @@ body.modal-open {
 }
 
 .activity-selector {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 }
 
-.activity-tab {
+.activity-picker-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--accent-strong);
+}
+
+.activity-picker {
+  position: relative;
+}
+
+.activity-picker-select {
+  width: 100%;
+  padding: 14px 44px 14px 16px;
   border: none;
-  padding: 12px 14px;
-  background: rgba(99, 102, 241, 0.08);
   border-radius: var(--radius-xs);
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.12), rgba(59, 130, 246, 0.1));
+  color: var(--accent-strong);
   font-weight: 600;
   font-size: 0.95rem;
-  color: var(--accent-strong);
-  cursor: pointer;
+  box-shadow: 0 18px 36px rgba(79, 70, 229, 0.25);
+  appearance: none;
   transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
+  cursor: pointer;
 }
 
-.activity-tab:hover,
-.activity-tab:focus-visible {
+.activity-picker-select:focus {
+  outline: 2px solid rgba(79, 70, 229, 0.5);
+  outline-offset: 2px;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.2), rgba(59, 130, 246, 0.16));
+}
+
+.activity-picker-select:disabled {
+  cursor: progress;
+  opacity: 0.7;
+  box-shadow: none;
+}
+
+.activity-picker:hover .activity-picker-select {
   transform: translateY(-2px);
-  box-shadow: 0 16px 30px rgba(99, 102, 241, 0.25);
+  box-shadow: 0 22px 42px rgba(79, 70, 229, 0.28);
 }
 
-.activity-tab.active {
-  background: linear-gradient(135deg, var(--accent), #8b5cf6);
-  color: white;
-  box-shadow: 0 20px 36px rgba(99, 102, 241, 0.35);
+.activity-picker-icon {
+  position: absolute;
+  pointer-events: none;
+  top: 50%;
+  right: 16px;
+  transform: translateY(-50%) rotate(45deg);
+  width: 12px;
+  height: 12px;
+  border-right: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  color: rgba(79, 70, 229, 0.75);
+  transform-origin: center;
+}
+
+.activity-picker-summary {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--text-muted);
 }
 
 .field {

--- a/index.html
+++ b/index.html
@@ -76,16 +76,23 @@
                 <ul id="activityTipExamples" class="activity-tip-list"></ul>
               </div>
             </div>
-            <div class="activity-selector" role="tablist">
-            <button class="activity-tab" data-activity="flipCards" role="tab">Flip cards</button>
-            <button class="activity-tab" data-activity="accordion" role="tab">Accordion</button>
-            <button class="activity-tab" data-activity="timeline" role="tab">Timeline</button>
-            <button class="activity-tab" data-activity="dragDrop" role="tab">Drag &amp; Drop</button>
-            <button class="activity-tab" data-activity="hotspots" role="tab">Hotspots</button>
-            <button class="activity-tab" data-activity="immersiveText" role="tab">Immersive text</button>
-            <button class="activity-tab" data-activity="branchingScenarios" role="tab">Branching scenarios</button>
-            <button class="activity-tab" data-activity="imageCarousel" role="tab">Image carousel</button>
-          </div>
+            <div class="activity-selector">
+              <label class="activity-picker-label" for="activitySelect">Activity template</label>
+              <div class="activity-picker">
+                <select id="activitySelect" class="activity-picker-select" aria-label="Choose an activity template">
+                  <option value="flipCards">Flip cards</option>
+                  <option value="accordion">Accordion</option>
+                  <option value="timeline">Timeline</option>
+                  <option value="dragDrop">Drag &amp; Drop</option>
+                  <option value="hotspots">Hotspots</option>
+                  <option value="immersiveText">Immersive text</option>
+                  <option value="branchingScenarios">Branching scenarios</option>
+                  <option value="imageCarousel">Image carousel</option>
+                </select>
+                <span class="activity-picker-icon" aria-hidden="true"></span>
+              </div>
+              <p id="activitySelectSummary" class="activity-picker-summary" aria-live="polite"></p>
+            </div>
           </section>
           <section class="panel-block">
             <h2 class="panel-title">General settings</h2>


### PR DESCRIPTION
## Summary
- replace the grid of activity tabs with a single dropdown selector in the control panel
- refresh the styling to match the new picker and surface the active template summary
- update activity switching logic to work with the dropdown experience

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7498635f8832b80bff1428a3a040f