### PR TITLE
Reorder activity chooser and expand tips by default

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -124,7 +124,7 @@ const modalState = {
 };
 
 let previewHidden = false;
-let tipsExpanded = false;
+let tipsExpanded = true;
 
 const isElementVisible = (element) => {
   if (!element) return false;
@@ -254,7 +254,7 @@ const updateActivityTip = () => {
   setTipsExpanded(shouldExpand);
 };
 
-setTipsExpanded(false);
+setTipsExpanded(true);
 
 const getActiveActivity = () => {
   const activity = activities[state.type];

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -249,6 +249,12 @@ body.modal-open {
   flex: 1 1 auto;
 }
 
+.learning-tips {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
 .tip-toggle {
   display: inline-flex;
   align-items: center;

--- a/index.html
+++ b/index.html
@@ -41,41 +41,7 @@
       <main class="app-main">
         <aside class="control-panel" aria-label="Activity configuration">
           <section class="panel-block">
-            <div class="panel-header panel-header--tips">
-              <h2 class="panel-title">Choose an activity</h2>
-              <button
-                id="activityTipToggle"
-                class="tip-toggle"
-                type="button"
-                aria-expanded="false"
-                aria-controls="activityTipPanel"
-              >
-                <span class="tip-icon" aria-hidden="true">💡</span>
-                <span id="activityTipToggleLabel" class="tip-label">Show learning tips</span>
-              </button>
-            </div>
-            <div
-              id="activityTipPanel"
-              class="activity-tip"
-              hidden
-              role="region"
-              aria-live="polite"
-            >
-              <h3 id="activityTipTitle" class="activity-tip-title"></h3>
-              <p id="activityTipIntro" class="activity-tip-intro"></p>
-              <div id="activityTipWhenSection" class="activity-tip-section">
-                <h4 class="activity-tip-heading">When to use it</h4>
-                <p id="activityTipWhen" class="activity-tip-body"></p>
-              </div>
-              <div id="activityTipConsiderationsSection" class="activity-tip-section">
-                <h4 class="activity-tip-heading">Design considerations</h4>
-                <ul id="activityTipConsiderations" class="activity-tip-list"></ul>
-              </div>
-              <div id="activityTipExamplesSection" class="activity-tip-section">
-                <h4 class="activity-tip-heading">Quick examples</h4>
-                <ul id="activityTipExamples" class="activity-tip-list"></ul>
-              </div>
-            </div>
+            <h2 class="panel-title">Choose an activity</h2>
             <div class="activity-selector">
               <label class="activity-picker-label" for="activitySelect">Activity template</label>
               <div class="activity-picker">
@@ -92,6 +58,37 @@
                 <span class="activity-picker-icon" aria-hidden="true"></span>
               </div>
               <p id="activitySelectSummary" class="activity-picker-summary" aria-live="polite"></p>
+            </div>
+            <div class="learning-tips">
+              <div class="panel-header panel-header--tips">
+                <h3 class="panel-title">Learning tips</h3>
+                <button
+                  id="activityTipToggle"
+                  class="tip-toggle"
+                  type="button"
+                  aria-expanded="true"
+                  aria-controls="activityTipPanel"
+                >
+                  <span class="tip-icon" aria-hidden="true">💡</span>
+                  <span id="activityTipToggleLabel" class="tip-label">Hide learning tips</span>
+                </button>
+              </div>
+              <div id="activityTipPanel" class="activity-tip" role="region" aria-live="polite">
+                <h3 id="activityTipTitle" class="activity-tip-title"></h3>
+                <p id="activityTipIntro" class="activity-tip-intro"></p>
+                <div id="activityTipWhenSection" class="activity-tip-section">
+                  <h4 class="activity-tip-heading">When to use it</h4>
+                  <p id="activityTipWhen" class="activity-tip-body"></p>
+                </div>
+                <div id="activityTipConsiderationsSection" class="activity-tip-section">
+                  <h4 class="activity-tip-heading">Design considerations</h4>
+                  <ul id="activityTipConsiderations" class="activity-tip-list"></ul>
+                </div>
+                <div id="activityTipExamplesSection" class="activity-tip-section">
+                  <h4 class="activity-tip-heading">Quick examples</h4>
+                  <ul id="activityTipExamples" class="activity-tip-list"></ul>
+                </div>
+              </div>
             </div>
           </section>
           <section class="panel-block">


### PR DESCRIPTION
## Summary
- reorder the activity selector so it appears before the learning tips section
- show the learning tips panel by default and synchronize the toggle labeling
- add layout styling for the updated learning tips wrapper

## Testing
- Manual smoke test in browser

------
https://chatgpt.com/codex/tasks/task_e_68d74c2dd3d4832b86c5509d4fcee393