### PR TITLE
Optimize media uploads for carousel and hotspots

### DIFF
--- a/assets/js/activities/hotspots.js
+++ b/assets/js/activities/hotspots.js
@@ -1,5 +1,11 @@
 import { clone, compressImageFile, uid, escapeHtml } from '../utils.js';
 
+const HOTSPOT_IMAGE_COMPRESSION = {
+  maxWidth: 1400,
+  maxHeight: 1400,
+  quality: 0.8
+};
+
 const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
 
 const createSampleHotspots = () => [
@@ -57,7 +63,7 @@ const buildEditor = (container, data, onUpdate) => {
   const handleImageUpload = async (file) => {
     if (!file) return;
     try {
-      const src = await compressImageFile(file, { maxWidth: 1600, maxHeight: 1600, quality: 0.82 });
+      const src = await compressImageFile(file, HOTSPOT_IMAGE_COMPRESSION);
       const existingAlt = working.image && typeof working.image.alt === 'string' ? working.image.alt : '';
       const defaultAlt = file
         ? file.name.replace(/\.[^.]+$/, '').replace(/[-_]/g, ' ')

--- a/assets/js/activities/imageCarousel.js
+++ b/assets/js/activities/imageCarousel.js
@@ -1,5 +1,11 @@
 import { clone, compressImageFile, escapeHtml, uid } from '../utils.js';
 
+const SLIDE_IMAGE_COMPRESSION = {
+  maxWidth: 1400,
+  maxHeight: 1400,
+  quality: 0.8
+};
+
 const clampAutoplaySeconds = (value) => {
   const parsed = Number(value);
   if (!Number.isFinite(parsed) || parsed < 0) {
@@ -105,7 +111,7 @@ const buildEditor = (container, data, onUpdate) => {
       return;
     }
     try {
-      const dataUrl = await compressImageFile(file, { maxWidth: 1600, maxHeight: 1600, quality: 0.82 });
+      const dataUrl = await compressImageFile(file, SLIDE_IMAGE_COMPRESSION);
       working.slides[index].imageUrl = dataUrl;
       emit();
     } catch (error) {
@@ -124,6 +130,15 @@ const buildEditor = (container, data, onUpdate) => {
 
   const rerender = () => {
     container.innerHTML = '';
+
+    const createIconButton = (label, pathData) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'muted-button icon-button';
+      button.setAttribute('aria-label', label);
+      button.innerHTML = `<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path fill="currentColor" d="${pathData}" /></svg>`;
+      return button;
+    };
 
     const settingsBlock = document.createElement('div');
     settingsBlock.className = 'editor-block';
@@ -178,17 +193,11 @@ const buildEditor = (container, data, onUpdate) => {
       const actions = document.createElement('div');
       actions.className = 'editor-item-actions';
 
-      const upButton = document.createElement('button');
-      upButton.type = 'button';
-      upButton.className = 'muted-button';
-      upButton.textContent = 'Move up';
+      const upButton = createIconButton('Move slide up', 'M12 6L7 11h10l-5-5z');
       upButton.disabled = index === 0;
       upButton.addEventListener('click', () => moveSlide(index, index - 1));
 
-      const downButton = document.createElement('button');
-      downButton.type = 'button';
-      downButton.className = 'muted-button';
-      downButton.textContent = 'Move down';
+      const downButton = createIconButton('Move slide down', 'M12 18l5-5H7l5 5z');
       downButton.disabled = index === working.slides.length - 1;
       downButton.addEventListener('click', () => moveSlide(index, index + 1));
 

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -1639,6 +1639,40 @@ textarea:focus {
   font-size: 0.85rem;
 }
 
+.muted-button.icon-button {
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px;
+  border-radius: var(--radius-xs);
+  transition: background-color var(--transition), color var(--transition), box-shadow var(--transition);
+}
+
+.muted-button.icon-button svg {
+  width: 16px;
+  height: 16px;
+  pointer-events: none;
+}
+
+.muted-button.icon-button:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.muted-button.icon-button:not(:disabled):hover,
+.muted-button.icon-button:not(:disabled):focus-visible {
+  background: var(--accent-soft);
+  color: var(--accent-strong);
+}
+
+.muted-button.icon-button:focus-visible {
+  outline: 2px solid rgba(99, 102, 241, 0.35);
+  outline-offset: 2px;
+  box-shadow: 0 4px 12px rgba(99, 102, 241, 0.18);
+}
+
 .hotspot-image-input {
   display: grid;
   gap: 12px;

--- a/docs/assets/js/activities/hotspots.js
+++ b/docs/assets/js/activities/hotspots.js
@@ -1,5 +1,11 @@
 import { clone, compressImageFile, uid, escapeHtml } from '../utils.js';
 
+const HOTSPOT_IMAGE_COMPRESSION = {
+  maxWidth: 1400,
+  maxHeight: 1400,
+  quality: 0.8
+};
+
 const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
 
 const createSampleHotspots = () => [
@@ -57,7 +63,7 @@ const buildEditor = (container, data, onUpdate) => {
   const handleImageUpload = async (file) => {
     if (!file) return;
     try {
-      const src = await compressImageFile(file, { maxWidth: 1600, maxHeight: 1600, quality: 0.82 });
+      const src = await compressImageFile(file, HOTSPOT_IMAGE_COMPRESSION);
       const existingAlt = working.image && typeof working.image.alt === 'string' ? working.image.alt : '';
       const defaultAlt = file
         ? file.name.replace(/\.[^.]+$/, '').replace(/[-_]/g, ' ')

--- a/docs/assets/js/activities/imageCarousel.js
+++ b/docs/assets/js/activities/imageCarousel.js
@@ -1,5 +1,11 @@
 import { clone, compressImageFile, escapeHtml, uid } from '../utils.js';
 
+const SLIDE_IMAGE_COMPRESSION = {
+  maxWidth: 1400,
+  maxHeight: 1400,
+  quality: 0.8
+};
+
 const clampAutoplaySeconds = (value) => {
   const parsed = Number(value);
   if (!Number.isFinite(parsed) || parsed < 0) {
@@ -105,7 +111,7 @@ const buildEditor = (container, data, onUpdate) => {
       return;
     }
     try {
-      const dataUrl = await compressImageFile(file, { maxWidth: 1600, maxHeight: 1600, quality: 0.82 });
+      const dataUrl = await compressImageFile(file, SLIDE_IMAGE_COMPRESSION);
       working.slides[index].imageUrl = dataUrl;
       emit();
     } catch (error) {
@@ -124,6 +130,15 @@ const buildEditor = (container, data, onUpdate) => {
 
   const rerender = () => {
     container.innerHTML = '';
+
+    const createIconButton = (label, pathData) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.className = 'muted-button icon-button';
+      button.setAttribute('aria-label', label);
+      button.innerHTML = `<svg viewBox="0 0 24 24" aria-hidden="true" focusable="false"><path fill="currentColor" d="${pathData}" /></svg>`;
+      return button;
+    };
 
     const settingsBlock = document.createElement('div');
     settingsBlock.className = 'editor-block';
@@ -178,17 +193,11 @@ const buildEditor = (container, data, onUpdate) => {
       const actions = document.createElement('div');
       actions.className = 'editor-item-actions';
 
-      const upButton = document.createElement('button');
-      upButton.type = 'button';
-      upButton.className = 'muted-button';
-      upButton.textContent = 'Move up';
+      const upButton = createIconButton('Move slide up', 'M12 6L7 11h10l-5-5z');
       upButton.disabled = index === 0;
       upButton.addEventListener('click', () => moveSlide(index, index - 1));
 
-      const downButton = document.createElement('button');
-      downButton.type = 'button';
-      downButton.className = 'muted-button';
-      downButton.textContent = 'Move down';
+      const downButton = createIconButton('Move slide down', 'M12 18l5-5H7l5 5z');
       downButton.disabled = index === working.slides.length - 1;
       downButton.addEventListener('click', () => moveSlide(index, index + 1));
 


### PR DESCRIPTION
## Summary
- compress uploaded carousel slide images more aggressively and introduce icon-only controls in the authoring UI
- apply the same optimized compression settings to hotspot background uploads to speed up loading and reduce storage needs
- add shared styling for the new icon buttons used in editors

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d74dc3889c832b8dd352b73cfb0f28