### PR TITLE
Fix flipcard face overlap by locking transforms

### DIFF
--- a/assets/js/activities/flipCards.js
+++ b/assets/js/activities/flipCards.js
@@ -656,8 +656,13 @@ const embedTemplate = (data, containerId) => {
       margin: 0;
       line-height: 1.4;
     }
+    #${containerId} .cd-flipcard-front {
+      transform: rotateY(0deg);
+      -webkit-transform: rotateY(0deg);
+    }
     #${containerId} .cd-flipcard-back {
       transform: rotateY(180deg);
+      -webkit-transform: rotateY(180deg);
     }
     @keyframes cd-flipcard-reveal {
       from {

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -840,6 +840,11 @@ textarea:focus {
 
 .flipcard-back {
   transform: rotateY(180deg);
+  -webkit-transform: rotateY(180deg);
+}
+.flipcard-front {
+  transform: rotateY(0deg);
+  -webkit-transform: rotateY(0deg);
 }
 .flipcard-face.has-image {
   color: #f8fafc;

--- a/docs/assets/js/activities/flipCards.js
+++ b/docs/assets/js/activities/flipCards.js
@@ -650,8 +650,13 @@ const embedTemplate = (data, containerId) => {
       margin: 0;
       line-height: 1.4;
     }
+    #${containerId} .cd-flipcard-front {
+      transform: rotateY(0deg);
+      -webkit-transform: rotateY(0deg);
+    }
     #${containerId} .cd-flipcard-back {
       transform: rotateY(180deg);
+      -webkit-transform: rotateY(180deg);
     }
     @keyframes cd-flipcard-reveal {
       from {


### PR DESCRIPTION
## Summary
- ensure flipcard front faces explicitly retain a 0° rotation so they stay hidden when the back face is showing
- add WebKit-prefixed transforms for both front and back faces in generated embed styles

## Testing
- Manual QA - Loaded index.html via python http.server and confirmed flipcards render one face at a time

------
https://chatgpt.com/codex/tasks/task_e_68d7b080df0c832bac80602548b00349