### PR TITLE
Prioritize inline payload for Canvas embeds

### DIFF
--- a/docs/assets/js/embedViewer.js
+++ b/docs/assets/js/embedViewer.js
@@ -175,6 +175,11 @@ const fetchProjectDocument = async (projectId) => {
 };
 
 const resolvePayload = async () => {
+  const inline = parseInlinePayload();
+  if (inline && typeof inline === 'object') {
+    return inline;
+  }
+
   const params = new URLSearchParams(window.location.search);
   const embedId = params.get('embedId');
 
@@ -189,7 +194,7 @@ const resolvePayload = async () => {
     }
   }
 
-  return parseInlinePayload();
+  return null;
 };
 
 const hydratePayload = async (payload) => {


### PR DESCRIPTION
## Summary
- prefer the inline payload encoded in the iframe URL so Canvas loads immediately
- only request embed data from the parent window when inline data is missing

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d879f18b98832b8912997da459ef62