### PR TITLE
Allow the preview panel to use page scrolling

### DIFF
--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -698,8 +698,6 @@ textarea:focus {
   display: flex;
   flex-direction: column;
   gap: 24px;
-  height: calc(100vh - 56px);
-  max-height: calc(100vh - 56px);
 }
 
 .app-main.preview-hidden {
@@ -719,12 +717,12 @@ textarea:focus {
 
 .preview-area {
   position: relative;
-  flex: 1;
+  flex: initial;
   background: white;
   border-radius: calc(var(--radius) + 8px);
   border: 1px solid rgba(15, 23, 42, 0.05);
   padding: 32px;
-  overflow: auto;
+  overflow: visible;
   box-shadow: inset 0 6px 20px rgba(15, 23, 42, 0.04);
   min-height: 0;
 }


### PR DESCRIPTION
## Summary
- let the live preview panel size to its content so the browser scrollbar handles overflow
- remove the inner scroll frame by resetting the preview area's flex behavior and overflow

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d87faf8170832bb9bb8906567466a4