### PR TITLE
Reduce embed snippet size for saved activities

### DIFF
--- a/assets/js/embedViewer.js
+++ b/assets/js/embedViewer.js
@@ -1,6 +1,14 @@
 import { activities } from './activities/index.js';
 
 const VIEW_ROOT_ID = 'cd-embed-viewer-root';
+const REQUEST_MESSAGE_TYPE = 'canvas-designer:request-payload';
+const DELIVER_MESSAGE_TYPE = 'canvas-designer:deliver-payload';
+const PARENT_RESPONSE_TIMEOUT = 8000;
+
+const FIRESTORE_PROJECT_ID = 'tdt-sandbox';
+const FIRESTORE_COLLECTION = 'canvasDesignerActivities';
+const FIRESTORE_API_KEY = 'AIzaSyBLj8Ql3rEOLmIiVW6IDa8uJNGFLNbhA6U';
+const FIRESTORE_BASE_URL = `https://firestore.googleapis.com/v1/projects/${FIRESTORE_PROJECT_ID}/databases/(default)/documents/${FIRESTORE_COLLECTION}`;
 
 const baseStyles = (containerId) => `
   #${containerId} {
@@ -53,7 +61,7 @@ const decodeBase64Url = (value) => {
   return decodeURIComponent(escaped);
 };
 
-const parsePayload = () => {
+const parseInlinePayload = () => {
   const params = new URLSearchParams(window.location.search);
   let raw = params.get('data');
   if (!raw && window.location.hash.length > 1) {
@@ -74,6 +82,155 @@ const parsePayload = () => {
     console.warn('Unable to parse embed payload', error);
     return null;
   }
+};
+
+const requestPayloadFromParent = (embedId) =>
+  new Promise((resolve, reject) => {
+    if (!embedId || window.parent === window || !window.parent) {
+      reject(new Error('No parent window available for payload request.'));
+      return;
+    }
+
+    const handleMessage = (event) => {
+      const message = event?.data;
+      if (!message || message.type !== DELIVER_MESSAGE_TYPE || message.id !== embedId) {
+        return;
+      }
+
+      window.removeEventListener('message', handleMessage);
+      clearTimeout(timeoutId);
+      resolve(message.payload);
+    };
+
+    const timeoutId = setTimeout(() => {
+      window.removeEventListener('message', handleMessage);
+      reject(new Error('Timed out waiting for parent payload.'));
+    }, PARENT_RESPONSE_TIMEOUT);
+
+    window.addEventListener('message', handleMessage);
+
+    try {
+      window.parent.postMessage({ type: REQUEST_MESSAGE_TYPE, id: embedId }, '*');
+    } catch (error) {
+      window.removeEventListener('message', handleMessage);
+      clearTimeout(timeoutId);
+      reject(error);
+    }
+  });
+
+const decodeFirestoreValue = (value) => {
+  if (!value || typeof value !== 'object') {
+    return null;
+  }
+  if ('stringValue' in value) return value.stringValue;
+  if ('booleanValue' in value) return Boolean(value.booleanValue);
+  if ('integerValue' in value) return Number(value.integerValue);
+  if ('doubleValue' in value) return value.doubleValue;
+  if ('nullValue' in value) return null;
+  if ('timestampValue' in value) return value.timestampValue;
+  if ('arrayValue' in value) {
+    const { values } = value.arrayValue || {};
+    if (!Array.isArray(values)) return [];
+    return values.map((entry) => decodeFirestoreValue(entry));
+  }
+  if ('mapValue' in value) {
+    const fields = value.mapValue?.fields || {};
+    return Object.fromEntries(Object.entries(fields).map(([key, entry]) => [key, decodeFirestoreValue(entry)]));
+  }
+  if ('bytesValue' in value) return value.bytesValue;
+  if ('referenceValue' in value) return value.referenceValue;
+  if ('geoPointValue' in value) return value.geoPointValue;
+  return null;
+};
+
+const fetchProjectDocument = async (projectId) => {
+  if (!projectId) {
+    return null;
+  }
+
+  const url = `${FIRESTORE_BASE_URL}/${encodeURIComponent(projectId)}?key=${FIRESTORE_API_KEY}`;
+
+  try {
+    const response = await fetch(url, { mode: 'cors' });
+    if (!response.ok) {
+      throw new Error(`Firestore responded with ${response.status}`);
+    }
+    const document = await response.json();
+    const fields = document?.fields;
+    if (!fields) {
+      return null;
+    }
+    return {
+      v: 1,
+      id: projectId,
+      title: decodeFirestoreValue(fields.title),
+      description: decodeFirestoreValue(fields.description),
+      type: decodeFirestoreValue(fields.type),
+      content: decodeFirestoreValue(fields.data),
+      updatedAt: decodeFirestoreValue(fields.updatedAt)
+    };
+  } catch (error) {
+    console.warn('Unable to fetch project data from Firestore', error);
+    return null;
+  }
+};
+
+const resolvePayload = async () => {
+  const inline = parseInlinePayload();
+  if (inline && typeof inline === 'object') {
+    return inline;
+  }
+
+  const params = new URLSearchParams(window.location.search);
+  const projectId = params.get('projectId');
+  if (projectId) {
+    const project = await fetchProjectDocument(projectId);
+    if (project) {
+      return project;
+    }
+  }
+  const embedId = params.get('embedId');
+
+  if (embedId) {
+    try {
+      const parentPayload = await requestPayloadFromParent(embedId);
+      if (parentPayload && typeof parentPayload === 'object') {
+        return parentPayload;
+      }
+    } catch (error) {
+      console.warn('Unable to retrieve payload from parent context', error);
+    }
+  }
+
+  return null;
+};
+
+const hydratePayload = async (payload) => {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+
+  const version = typeof payload.v === 'number' ? payload.v : 0;
+  if (version !== 1) {
+    return { error: 'This activity was created with an incompatible version.' };
+  }
+
+  if (payload.id) {
+    const latest = await fetchProjectDocument(payload.id);
+    if (latest) {
+      return {
+        v: 1,
+        id: latest.id,
+        type: latest.type || payload.type,
+        title: latest.title ?? payload.title,
+        description: latest.description ?? payload.description,
+        content: latest.content ?? payload.content,
+        updatedAt: latest.updatedAt || payload.updatedAt || null
+      };
+    }
+  }
+
+  return payload;
 };
 
 const showMessage = (root, message) => {
@@ -142,30 +299,36 @@ const renderActivity = (root, payload) => {
   }
 };
 
-const bootstrap = () => {
+const bootstrap = async () => {
   const root = document.getElementById(VIEW_ROOT_ID);
   if (!root) {
     console.warn('Viewer root element missing');
     return;
   }
 
-  const payload = parsePayload();
-  if (!payload) {
+  const basePayload = await resolvePayload();
+  if (!basePayload) {
     showMessage(root, 'No activity data provided.');
     return;
   }
 
-  const version = typeof payload.v === 'number' ? payload.v : 0;
-  if (version !== 1) {
-    showMessage(root, 'This activity was created with an incompatible version.');
+  const hydrated = await hydratePayload(basePayload);
+  if (!hydrated || hydrated.error) {
+    showMessage(root, hydrated?.error || 'Unable to load this activity.');
     return;
   }
 
-  renderActivity(root, payload);
+  renderActivity(root, hydrated);
 };
 
 if (document.readyState === 'loading') {
-  document.addEventListener('DOMContentLoaded', bootstrap);
+  document.addEventListener('DOMContentLoaded', () => {
+    bootstrap().catch((error) => {
+      console.error('Failed to bootstrap Canvas Designer embed viewer', error);
+    });
+  });
 } else {
-  bootstrap();
+  bootstrap().catch((error) => {
+    console.error('Failed to bootstrap Canvas Designer embed viewer', error);
+  });
 }

--- a/docs/assets/js/embedViewer.js
+++ b/docs/assets/js/embedViewer.js
@@ -161,6 +161,7 @@ const fetchProjectDocument = async (projectId) => {
       return null;
     }
     return {
+      v: 1,
       id: projectId,
       title: decodeFirestoreValue(fields.title),
       description: decodeFirestoreValue(fields.description),
@@ -181,6 +182,13 @@ const resolvePayload = async () => {
   }
 
   const params = new URLSearchParams(window.location.search);
+  const projectId = params.get('projectId');
+  if (projectId) {
+    const project = await fetchProjectDocument(projectId);
+    if (project) {
+      return project;
+    }
+  }
   const embedId = params.get('embedId');
 
   if (embedId) {


### PR DESCRIPTION
## Summary
- shorten generated embed snippet by omitting inline payload for saved activities and assigning a stable iframe name
- allow the embed viewer to resolve activities via the projectId query parameter before falling back to parent messaging
- mirror the production viewer updates in the unbundled assets version so saved embeds load consistently

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d88366d3e4832bb54a8a1447cc359b