### PR TITLE
Fix caption embed syntax error in caption activity

### DIFF
--- a/assets/js/activities/captionThis.js
+++ b/assets/js/activities/captionThis.js
@@ -981,8 +981,7 @@ const embedTemplate = (data, containerId, context = {}) => {
         entry.captions.forEach((caption) => {
           if (!caption || typeof caption.text !== 'string') return;
           image.captions.push({
-            id:
-              caption.id || 'caption-' + Math.random().toString(36).slice(2),
+            id: caption.id || 'caption-' + Math.random().toString(36).slice(2),
             text: caption.text,
             createdAt: caption.createdAt || new Date().toISOString(),
             source: 'learner'
@@ -1204,13 +1203,9 @@ const embedTemplate = (data, containerId, context = {}) => {
       const active = getActive();
       if (!active) return;
       const entry = {
-        id:
-          'caption-' +
-          Date.now().toString(36) +
-          '-' +
-          Math.random()
-            .toString(36)
-            .slice(2, 6),
+        id: `caption-${Date.now().toString(36)}-${Math.random()
+          .toString(36)
+          .slice(2, 6)}`,
         text: value,
         createdAt: new Date().toISOString(),
         source: 'learner'


### PR DESCRIPTION
## Summary
- ensure caption embed object literals keep property expressions on the same line as their keys to prevent syntax errors

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d88d0057c0832bb1cca92e0015fe05