### PR TITLE
Fix caption embed template syntax errors breaking viewer

### DIFF
--- a/assets/js/activities/captionThis.js
+++ b/assets/js/activities/captionThis.js
@@ -1203,9 +1203,13 @@ const embedTemplate = (data, containerId, context = {}) => {
       const active = getActive();
       if (!active) return;
       const entry = {
-        id: `caption-${Date.now().toString(36)}-${Math.random()
-          .toString(36)
-          .slice(2, 6)}`,
+        id:
+          'caption-' +
+          Date.now().toString(36) +
+          '-' +
+          Math.random()
+            .toString(36)
+            .slice(2, 6),
         text: value,
         createdAt: new Date().toISOString(),
         source: 'learner'

--- a/docs/assets/js/activities/captionThis.js
+++ b/docs/assets/js/activities/captionThis.js
@@ -980,8 +980,9 @@ const embedTemplate = (data, containerId, context = {}) => {
         if (!image || !Array.isArray(entry.captions)) return;
         entry.captions.forEach((caption) => {
           if (!caption || typeof caption.text !== 'string') return;
+          const fallbackId = 'caption-' + Math.random().toString(36).slice(2);
           image.captions.push({
-            id: caption.id || `caption-${Math.random().toString(36).slice(2)}`,
+            id: caption.id || fallbackId,
             text: caption.text,
             createdAt: caption.createdAt || new Date().toISOString(),
             source: 'learner'
@@ -1065,7 +1066,7 @@ const embedTemplate = (data, containerId, context = {}) => {
         indicator.textContent = 'No images configured yet.';
         return;
       }
-      indicator.textContent = `${state.index + 1} of ${images.length}`;
+      indicator.textContent = String(state.index + 1) + ' of ' + images.length;
     };
 
     const renderImage = () => {
@@ -1123,7 +1124,7 @@ const embedTemplate = (data, containerId, context = {}) => {
           if (formatted) {
             const meta = document.createElement('p');
             meta.className = 'cd-caption-meta';
-            meta.textContent = `Saved ${formatted}`;
+            meta.textContent = 'Saved ' + formatted;
             item.append(meta);
           }
           list.append(item);
@@ -1203,7 +1204,13 @@ const embedTemplate = (data, containerId, context = {}) => {
       const active = getActive();
       if (!active) return;
       const entry = {
-        id: `caption-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`,
+        id:
+          'caption-' +
+          Date.now().toString(36) +
+          '-' +
+          Math.random()
+            .toString(36)
+            .slice(2, 6),
         text: value,
         createdAt: new Date().toISOString(),
         source: 'learner'


### PR DESCRIPTION
## Summary
- replace nested template literals in the caption activity embed script with string concatenation so the viewer no longer throws
- mirror the fixes in the published docs bundle to keep the hosted viewer in sync

## Testing
- Manual verification of docs/embed.html rendering a sample flip card payload via Playwright

------
https://chatgpt.com/codex/tasks/task_e_68d891a2aa4c832badac616d2a603523