### PR TITLE
Fix Caption This embed messaging and sandbox permissions

### DIFF
--- a/assets/js/activities/captionThis.js
+++ b/assets/js/activities/captionThis.js
@@ -694,13 +694,13 @@ const embedTemplate = (data, containerId, context = {}) => {
         <button type="button" class="cd-caption-nav cd-caption-prev" aria-label="Previous image">${LEFT_ARROW_ICON}</button>
         <figure class="cd-caption-figure" data-figure>
           <img data-image alt="" hidden />
-          <div class="cd-caption-placeholder" data-placeholder>No images configured yet.</div>
+          <div class="cd-caption-placeholder" data-placeholder>Loading image…</div>
           <figcaption class="cd-caption-image-prompt" data-image-prompt hidden></figcaption>
         </figure>
         <button type="button" class="cd-caption-nav cd-caption-next" aria-label="Next image">${RIGHT_ARROW_ICON}</button>
       </div>
       <div class="cd-caption-indicator" data-indicator>${
-        images.length ? `1 of ${images.length}` : 'No images configured yet.'
+        images.length ? `1 of ${images.length}` : 'Loading activity…'
       }</div>
       <div class="cd-caption-actions">
         <button type="button" class="cd-caption-button" data-add>Add a caption</button>

--- a/assets/js/embed.js
+++ b/assets/js/embed.js
@@ -134,7 +134,7 @@ export const generateEmbed = ({ id, type, title, description, data }) => {
   name="${embedId}"
   loading="lazy"
   referrerpolicy="no-referrer"
-  sandbox="allow-scripts allow-same-origin"
+  sandbox="allow-scripts allow-same-origin allow-forms"
   style="width: 100%; min-height: 420px; border: 0; border-radius: 12px; overflow: hidden; background-color: transparent;"
   src="${viewerUrl.toString()}"
 ></iframe>`;

--- a/docs/assets/js/activities/captionThis.js
+++ b/docs/assets/js/activities/captionThis.js
@@ -694,13 +694,13 @@ const embedTemplate = (data, containerId, context = {}) => {
         <button type="button" class="cd-caption-nav cd-caption-prev" aria-label="Previous image">${LEFT_ARROW_ICON}</button>
         <figure class="cd-caption-figure" data-figure>
           <img data-image alt="" hidden />
-          <div class="cd-caption-placeholder" data-placeholder>No images configured yet.</div>
+          <div class="cd-caption-placeholder" data-placeholder>Loading image…</div>
           <figcaption class="cd-caption-image-prompt" data-image-prompt hidden></figcaption>
         </figure>
         <button type="button" class="cd-caption-nav cd-caption-next" aria-label="Next image">${RIGHT_ARROW_ICON}</button>
       </div>
       <div class="cd-caption-indicator" data-indicator>${
-        images.length ? `1 of ${images.length}` : 'No images configured yet.'
+        images.length ? `1 of ${images.length}` : 'Loading activity…'
       }</div>
       <div class="cd-caption-actions">
         <button type="button" class="cd-caption-button" data-add>Add a caption</button>


### PR DESCRIPTION
## Summary
- update the Caption This embed placeholder and indicator copy so the iframe shows a loading message while the activity data hydrates
- add allow-forms to the generated iframe sandbox so learners can submit captions when the embed is hosted in LMS sandboxes

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d8976c067c832b9448e2896ce92995