### PR TITLE
Refine embed viewer styling for Canvas integration

### DIFF
--- a/assets/js/embedViewer.js
+++ b/assets/js/embedViewer.js
@@ -12,26 +12,42 @@ const FIRESTORE_BASE_URL = `https://firestore.googleapis.com/v1/projects/${FIRES
 
 const baseStyles = (containerId) => `
   #${containerId} {
-    font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-    color: #0f172a;
+    --cd-font-family: 'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    --cd-font-size-base: 14px;
+    --cd-text-color: #1f2937;
+    --cd-text-muted: #4b5563;
+    font-family: var(--cd-font-family);
+    font-size: var(--cd-font-size-base);
+    color: var(--cd-text-color);
     line-height: 1.5;
     display: grid;
-    gap: 1rem;
+    gap: 1.25rem;
     background: transparent;
   }
   #${containerId} *,
   #${containerId} *::before,
   #${containerId} *::after {
     box-sizing: border-box;
+    font-family: inherit;
   }
   #${containerId} .cd-embed-title {
-    font-size: 1.25rem;
+    font-size: 1.5rem;
     font-weight: 600;
     margin: 0;
+    color: #111827;
   }
   #${containerId} .cd-embed-description {
     margin: 0;
-    color: rgba(15, 23, 42, 0.7);
+    font-size: 1rem;
+    line-height: 1.6;
+    color: var(--cd-text-muted);
+  }
+  #${containerId} .cd-embed-description + .cd-embed,
+  #${containerId} .cd-embed-title + .cd-embed {
+    margin-top: 0.5rem;
+  }
+  #${containerId} .cd-embed {
+    background: transparent;
   }
 `;
 

--- a/docs/assets/js/embedViewer.js
+++ b/docs/assets/js/embedViewer.js
@@ -12,26 +12,42 @@ const FIRESTORE_BASE_URL = `https://firestore.googleapis.com/v1/projects/${FIRES
 
 const baseStyles = (containerId) => `
   #${containerId} {
-    font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-    color: #0f172a;
+    --cd-font-family: 'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+    --cd-font-size-base: 14px;
+    --cd-text-color: #1f2937;
+    --cd-text-muted: #4b5563;
+    font-family: var(--cd-font-family);
+    font-size: var(--cd-font-size-base);
+    color: var(--cd-text-color);
     line-height: 1.5;
     display: grid;
-    gap: 1rem;
+    gap: 1.25rem;
     background: transparent;
   }
   #${containerId} *,
   #${containerId} *::before,
   #${containerId} *::after {
     box-sizing: border-box;
+    font-family: inherit;
   }
   #${containerId} .cd-embed-title {
-    font-size: 1.25rem;
+    font-size: 1.5rem;
     font-weight: 600;
     margin: 0;
+    color: #111827;
   }
   #${containerId} .cd-embed-description {
     margin: 0;
-    color: rgba(15, 23, 42, 0.7);
+    font-size: 1rem;
+    line-height: 1.6;
+    color: var(--cd-text-muted);
+  }
+  #${containerId} .cd-embed-description + .cd-embed,
+  #${containerId} .cd-embed-title + .cd-embed {
+    margin-top: 0.5rem;
+  }
+  #${containerId} .cd-embed {
+    background: transparent;
   }
 `;
 

--- a/docs/embed.html
+++ b/docs/embed.html
@@ -4,15 +4,10 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Canvas Designer Viewer</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
-      rel="stylesheet"
-    />
     <style>
       :root {
         color-scheme: light;
+        font-size: 14px;
       }
       *,
       *::before,
@@ -22,13 +17,16 @@
       html,
       body {
         background: transparent;
+        height: 100%;
       }
       body {
         margin: 0;
-        min-height: 100vh;
-        font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-        color: #0f172a;
-        padding: clamp(1rem, 2vw + 0.5rem, 2rem);
+        min-height: 0;
+        font-family: 'Lato', 'Helvetica Neue', Helvetica, Arial, sans-serif;
+        font-size: 14px;
+        line-height: 1.5;
+        color: #1f2937;
+        padding: 0;
       }
       .cd-embed-viewer-shell {
         width: min(960px, 100%);
@@ -37,6 +35,9 @@
         border-radius: 0;
         padding: 0;
         box-shadow: none;
+        display: flex;
+        flex-direction: column;
+        gap: 1.5rem;
       }
       .cd-viewer-message {
         padding: 1.25rem;


### PR DESCRIPTION
## Summary
- update the standalone embed viewer shell to use a Canvas-aligned font stack, 14px base type, and transparent background without extra padding that triggered scrollbars
- refresh the injected base styles so embedded activities inherit the new typography, spacing, and transparent surface defaults in both the app and published docs build

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d89a0a9e54832bac9425956c69b53b