### PR TITLE
Ensure saved embeds include inline payload fallback

### DIFF
--- a/assets/js/embed.js
+++ b/assets/js/embed.js
@@ -105,7 +105,7 @@ export const generateEmbed = ({ id, type, title, description, data }) => {
   const safeTitle = sanitizeText(title);
   const safeDescription = sanitizeText(description, { maxLength: 1200 });
   const hasPersistentId = typeof id === 'string' && id.trim() !== '';
-  const includeInlineContent = !hasPersistentId;
+  const includeInlineContent = data && typeof data === 'object';
 
   const payload = {
     v: 1,
@@ -120,7 +120,9 @@ export const generateEmbed = ({ id, type, title, description, data }) => {
   if (includeInlineContent) {
     const encoded = encodePayload(payload);
     viewerUrl.hash = encoded;
-  } else if (hasPersistentId) {
+  }
+
+  if (hasPersistentId) {
     viewerUrl.searchParams.set('projectId', id);
   }
 


### PR DESCRIPTION
## Summary
- always encode the current activity data into the embed payload, even for saved projects with IDs
- retain the projectId query parameter so the viewer can hydrate from Firestore when available

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d89d9637d0832ba920ed807407c24b