### PR TITLE
Hide scrollbars in embedded viewer

### DIFF
--- a/docs/assets/js/embedViewer.js
+++ b/docs/assets/js/embedViewer.js
@@ -271,12 +271,13 @@ const applyFrameHeight = (height, { embedId } = {}) => {
   if (doc) {
     doc.style.height = `${targetHeight}px`;
     doc.style.minHeight = `${targetHeight}px`;
+    doc.style.overflow = 'hidden';
   }
 
   if (document.body) {
     document.body.style.height = `${targetHeight}px`;
     document.body.style.minHeight = `${targetHeight}px`;
-    document.body.style.overflowX = 'hidden';
+    document.body.style.overflow = 'hidden';
   }
 
   try {

--- a/docs/embed.html
+++ b/docs/embed.html
@@ -19,6 +19,7 @@
         background: transparent;
         height: auto;
         min-height: 100%;
+        overflow: hidden;
       }
       body {
         margin: 0;
@@ -28,7 +29,7 @@
         line-height: 1.5;
         color: #1f2937;
         padding: 0;
-        overflow-x: hidden;
+        overflow: hidden;
       }
       .cd-embed-viewer-shell {
         width: min(960px, 100%);


### PR DESCRIPTION
## Summary
- hide overflow on the embed viewer document to prevent nested scrollbars when activities render
- ensure the auto-resize logic also disables overflow on the html and body elements after sizing the frame

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8f4876824832b86cccc85aa03843d