### PR TITLE
Allow embed viewer page to scroll

### DIFF
--- a/docs/embed.html
+++ b/docs/embed.html
@@ -17,9 +17,10 @@
       html,
       body {
         background: transparent;
-        height: auto;
         min-height: 100%;
-        overflow: hidden;
+      }
+      html {
+        height: auto;
       }
       body {
         margin: 0;
@@ -29,7 +30,6 @@
         line-height: 1.5;
         color: #1f2937;
         padding: 0;
-        overflow: hidden;
       }
       .cd-embed-viewer-shell {
         width: min(960px, 100%);


### PR DESCRIPTION
## Summary
- allow the embed viewer to rely on the host page for scrolling by removing the forced overflow hidden on html/body

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d8f7f9df88832ba088ad7beb5184d8