### PR TITLE
Improve previews and embed resizing

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -322,10 +322,48 @@ const refreshEmbed = () => {
 
 const refreshPreview = () => {
   const activity = getActiveActivity();
-  if (!activity) return;
+  if (!activity || !elements.previewArea) return;
+
   const shouldPlayAnimations = elements.animationToggle ? elements.animationToggle.checked : true;
-  activity.renderPreview(elements.previewArea, state.data, {
-    playAnimations: shouldPlayAnimations
+  const title = typeof state.title === 'string' ? state.title.trim() : '';
+  const description = typeof state.description === 'string' ? state.description.trim() : '';
+
+  const wrapper = document.createElement('div');
+  wrapper.className = 'preview-activity-wrapper';
+
+  if (title || description) {
+    const meta = document.createElement('header');
+    meta.className = 'preview-activity-meta';
+
+    if (title) {
+      const heading = document.createElement('h3');
+      heading.className = 'preview-activity-title';
+      heading.textContent = title;
+      meta.append(heading);
+    }
+
+    if (description) {
+      const summary = document.createElement('p');
+      summary.className = 'preview-activity-description';
+      summary.textContent = description;
+      meta.append(summary);
+    }
+
+    wrapper.append(meta);
+  }
+
+  const activityContainer = document.createElement('div');
+  activityContainer.className = 'preview-activity-content';
+  wrapper.append(activityContainer);
+
+  elements.previewArea.innerHTML = '';
+  elements.previewArea.append(wrapper);
+
+  activity.renderPreview(activityContainer, state.data, {
+    playAnimations: shouldPlayAnimations,
+    title,
+    description,
+    stateHost: elements.previewArea
   });
 };
 
@@ -778,12 +816,18 @@ const bindEvents = () => {
   elements.titleInput.addEventListener('input', (event) => {
     state.title = event.target.value;
     refreshEmbed();
+    if (!previewHidden) {
+      refreshPreview();
+    }
   });
 
   if (elements.descriptionInput) {
     elements.descriptionInput.addEventListener('input', (event) => {
       state.description = event.target.value;
       refreshEmbed();
+      if (!previewHidden) {
+        refreshPreview();
+      }
     });
   }
 

--- a/assets/js/embedViewer.js
+++ b/assets/js/embedViewer.js
@@ -3,7 +3,9 @@ import { activities } from './activities/index.js';
 const VIEW_ROOT_ID = 'cd-embed-viewer-root';
 const REQUEST_MESSAGE_TYPE = 'canvas-designer:request-payload';
 const DELIVER_MESSAGE_TYPE = 'canvas-designer:deliver-payload';
+const RESIZE_MESSAGE_TYPE = 'canvas-designer:embed-resize';
 const PARENT_RESPONSE_TIMEOUT = 8000;
+const DEFAULT_MIN_HEIGHT = 420;
 
 const FIRESTORE_PROJECT_ID = 'tdt-sandbox';
 const FIRESTORE_COLLECTION = 'canvasDesignerActivities';
@@ -95,7 +97,7 @@ const parseInlinePayload = () => {
     }
     return payload;
   } catch (error) {
-    console.warn('Unable to parse embed payload', error);
+    console.warn('Unable to parse inline embed payload', error);
     return null;
   }
 };
@@ -258,7 +260,177 @@ const showMessage = (root, message) => {
   root.append(notice);
 };
 
-const renderActivity = (root, payload) => {
+const applyFrameHeight = (height, { embedId } = {}) => {
+  if (!Number.isFinite(height)) {
+    return;
+  }
+
+  const targetHeight = Math.max(Math.ceil(height), DEFAULT_MIN_HEIGHT);
+
+  const doc = document.documentElement;
+  if (doc) {
+    doc.style.height = `${targetHeight}px`;
+    doc.style.minHeight = `${targetHeight}px`;
+    doc.style.maxHeight = 'none';
+    doc.style.overflow = 'hidden';
+  }
+
+  if (document.body) {
+    document.body.style.height = `${targetHeight}px`;
+    document.body.style.minHeight = `${targetHeight}px`;
+    document.body.style.maxHeight = 'none';
+    document.body.style.overflow = 'hidden';
+  }
+
+  try {
+    const frame = window.frameElement;
+    if (frame && frame.style) {
+      frame.style.height = `${targetHeight}px`;
+      frame.style.minHeight = `${targetHeight}px`;
+      frame.style.maxHeight = 'none';
+      frame.style.overflow = 'hidden';
+    }
+  } catch (error) {
+    // Ignore cross-origin restrictions when we can't reach the frame element.
+  }
+
+  if (embedId && window.parent && window.parent !== window) {
+    try {
+      window.parent.postMessage(
+        {
+          type: RESIZE_MESSAGE_TYPE,
+          id: embedId,
+          height: targetHeight
+        },
+        '*'
+      );
+    } catch (error) {
+      // Ignore postMessage failures in restrictive parent contexts.
+    }
+  }
+};
+
+const setupAutoResize = (root, container, { embedId } = {}) => {
+  if (!root) {
+    return;
+  }
+
+  const containerEl = container instanceof Element ? container : null;
+  let lastHeight = 0;
+
+  const measure = () => {
+    const body = document.body;
+    const doc = document.documentElement;
+    const containerRect = containerEl ? containerEl.getBoundingClientRect() : null;
+
+    const measured = Math.max(
+      containerRect ? containerRect.height : 0,
+      containerEl?.scrollHeight || 0,
+      containerEl?.offsetHeight || 0,
+      root.scrollHeight || 0,
+      root.offsetHeight || 0,
+      body?.scrollHeight || 0,
+      body?.offsetHeight || 0,
+      doc?.scrollHeight || 0,
+      doc?.offsetHeight || 0
+    );
+
+    if (!Number.isFinite(measured)) {
+      return;
+    }
+
+    const nextHeight = Math.max(Math.ceil(measured + 16), DEFAULT_MIN_HEIGHT);
+
+    if (Math.abs(nextHeight - lastHeight) <= 1) {
+      return;
+    }
+
+    lastHeight = nextHeight;
+    applyFrameHeight(nextHeight, { embedId });
+  };
+
+  measure();
+
+  const cleanupFns = [];
+
+  if (typeof ResizeObserver === 'function') {
+    const observer = new ResizeObserver(() => measure());
+    observer.observe(root);
+    if (containerEl && containerEl !== root) {
+      observer.observe(containerEl);
+    }
+    cleanupFns.push(() => observer.disconnect());
+  } else {
+    let rafId = null;
+    const poll = () => {
+      measure();
+      rafId = window.requestAnimationFrame(poll);
+    };
+    poll();
+
+    cleanupFns.push(() => {
+      if (rafId) {
+        window.cancelAnimationFrame(rafId);
+        rafId = null;
+      }
+    });
+  }
+
+  if (typeof MutationObserver === 'function') {
+    const mutationObserver = new MutationObserver(() => measure());
+    mutationObserver.observe(root, { childList: true, subtree: true, attributes: true, characterData: true });
+    if (containerEl && containerEl !== root) {
+      mutationObserver.observe(containerEl, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        characterData: true
+      });
+    }
+    cleanupFns.push(() => mutationObserver.disconnect());
+  }
+
+  const handleLoad = () => measure();
+  const handleResize = () => measure();
+  window.addEventListener('load', handleLoad);
+  window.addEventListener('resize', handleResize);
+  cleanupFns.push(() => {
+    window.removeEventListener('load', handleLoad);
+    window.removeEventListener('resize', handleResize);
+  });
+
+  if (document.fonts) {
+    const handleFontLoad = () => measure();
+    if (typeof document.fonts.addEventListener === 'function') {
+      document.fonts.addEventListener('loadingdone', handleFontLoad);
+      cleanupFns.push(() => document.fonts.removeEventListener('loadingdone', handleFontLoad));
+    } else if (typeof document.fonts.ready?.then === 'function') {
+      document.fonts.ready.then(() => measure()).catch(() => {});
+    }
+  }
+
+  const settleTimers = [
+    window.setTimeout(measure, 250),
+    window.setTimeout(measure, 1000),
+    window.setTimeout(measure, 2500)
+  ];
+  cleanupFns.push(() => settleTimers.forEach((timer) => window.clearTimeout(timer)));
+
+  const cleanup = () => {
+    while (cleanupFns.length) {
+      const fn = cleanupFns.shift();
+      try {
+        fn();
+      } catch (error) {
+        // Ignore cleanup failures.
+      }
+    }
+  };
+
+  window.addEventListener('pagehide', cleanup, { once: true });
+};
+
+const renderActivity = (root, payload, { embedId } = {}) => {
   const type = typeof payload.type === 'string' ? payload.type.trim() : '';
   const activity = activities[type];
 
@@ -313,6 +485,8 @@ const renderActivity = (root, payload) => {
     script.textContent = parts.js;
     document.body.append(script);
   }
+
+  setupAutoResize(root, container, { embedId });
 };
 
 const bootstrap = async () => {
@@ -321,6 +495,9 @@ const bootstrap = async () => {
     console.warn('Viewer root element missing');
     return;
   }
+
+  const params = new URLSearchParams(window.location.search);
+  const embedId = params.get('embedId');
 
   const basePayload = await resolvePayload();
   if (!basePayload) {
@@ -334,7 +511,7 @@ const bootstrap = async () => {
     return;
   }
 
-  renderActivity(root, hydrated);
+  renderActivity(root, hydrated, { embedId });
 };
 
 if (document.readyState === 'loading') {

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -727,6 +727,34 @@ textarea:focus {
   min-height: 0;
 }
 
+.preview-activity-wrapper {
+  display: grid;
+  gap: 24px;
+}
+
+.preview-activity-meta {
+  display: grid;
+  gap: 8px;
+}
+
+.preview-activity-title {
+  margin: 0;
+  font-size: clamp(1.25rem, 2.6vw, 1.7rem);
+  font-weight: 600;
+  color: var(--text-stronger);
+}
+
+.preview-activity-description {
+  margin: 0;
+  line-height: 1.6;
+  color: var(--text-muted);
+  font-size: 1rem;
+}
+
+.preview-activity-content {
+  display: block;
+}
+
 .empty-state {
   height: 100%;
   display: grid;
@@ -879,118 +907,105 @@ textarea:focus {
   border: 1px solid rgba(99, 102, 241, 0.14);
 }
 
-.wordcloud-preview {
+.cd-wordcloud {
   display: grid;
-  gap: 1rem;
-  padding: 24px;
-  border-radius: var(--radius);
+  gap: 20px;
+  padding: clamp(1.2rem, 3vw, 1.8rem);
   background: linear-gradient(145deg, rgba(99, 102, 241, 0.12), rgba(14, 165, 233, 0.08));
+  border-radius: 20px;
   border: 1px solid rgba(99, 102, 241, 0.18);
-  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
 }
 
-.wordcloud-preview-header {
+.cd-wordcloud-header {
   display: grid;
-  gap: 0.35rem;
+  gap: 0.5rem;
 }
 
-.wordcloud-preview-prompt {
+.cd-wordcloud-title {
   margin: 0;
-  font-size: 1.15rem;
+  font-size: clamp(1.15rem, 2vw, 1.5rem);
   font-weight: 600;
   color: rgba(15, 23, 42, 0.92);
 }
 
-.wordcloud-preview-instructions {
+.cd-wordcloud-instructions {
   margin: 0;
-  color: rgba(15, 23, 42, 0.65);
+  color: rgba(15, 23, 42, 0.7);
   font-size: 0.95rem;
 }
 
-.wordcloud-preview-form {
-  display: grid;
-  gap: 0.5rem;
-  background: rgba(99, 102, 241, 0.08);
-  border-radius: 12px;
-  padding: 0.75rem 1rem;
+.cd-wordcloud-cap {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(99, 102, 241, 0.8);
+  font-weight: 500;
 }
 
-.wordcloud-preview-form-label {
-  font-size: 0.85rem;
+.cd-wordcloud-form {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.cd-wordcloud-label {
   font-weight: 600;
+  font-size: 0.9rem;
   color: rgba(79, 70, 229, 0.85);
 }
 
-.wordcloud-preview-input {
+.cd-wordcloud-input {
   display: flex;
-  gap: 0.5rem;
+  gap: 0.6rem;
   align-items: center;
   flex-wrap: wrap;
 }
 
-.wordcloud-preview-input input {
+.cd-wordcloud-input input {
   flex: 1;
   border-radius: 999px;
   border: 1px solid rgba(99, 102, 241, 0.35);
-  padding: 0.55rem 1rem;
+  padding: 0.6rem 1rem;
   font-family: inherit;
-  background: rgba(255, 255, 255, 0.7);
-  min-width: 140px;
-}
-
-.wordcloud-preview-input button {
-  border-radius: 999px;
-  border: none;
-  padding: 0.55rem 1.1rem;
-  background: rgba(99, 102, 241, 0.9);
-  color: #fff;
-  font-weight: 600;
-}
-
-.wordcloud-preview-status {
-  margin: 0;
-  font-size: 0.85rem;
-  color: rgba(30, 64, 175, 0.85);
-}
-
-.wordcloud-preview-status[data-tone='error'] {
-  color: rgba(185, 28, 28, 0.9);
-}
-
-.wordcloud-preview-actions {
-  display: flex;
-  gap: 0.5rem;
-  justify-content: flex-end;
-}
-
-.wordcloud-preview-actions button {
-  border-radius: 999px;
-  border: none;
-  padding: 0.45rem 1rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: transform 160ms ease, box-shadow 160ms ease;
-}
-
-.wordcloud-preview-toggle {
-  background: rgba(30, 64, 175, 0.9);
-  color: #fff;
-  box-shadow: 0 10px 22px rgba(30, 64, 175, 0.2);
-}
-
-.wordcloud-preview-reset {
   background: rgba(255, 255, 255, 0.85);
-  color: rgba(30, 41, 59, 0.85);
-  border: 1px solid rgba(99, 102, 241, 0.24);
+  min-width: 140px;
+  transition: border-color 160ms ease, box-shadow 160ms ease;
 }
 
-.wordcloud-preview-actions button:hover {
-  transform: translateY(-1px);
+.cd-wordcloud-input input:focus {
+  border-color: rgba(79, 70, 229, 0.85);
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.22);
 }
 
-.wordcloud-preview-cloud {
+.cd-wordcloud-input button {
+  border-radius: 999px;
+  border: none;
+  padding: 0.6rem 1.2rem;
+  background: rgba(79, 70, 229, 0.92);
+  color: #fff;
+  font-weight: 600;
+}
+
+.cd-wordcloud-status {
+  margin: 0;
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: rgba(79, 70, 229, 0.95);
+}
+
+.cd-wordcloud-status[data-tone='error'] {
+  color: rgba(220, 38, 38, 0.85);
+}
+
+.cd-wordcloud-status[data-tone='limit'] {
+  background: rgba(99, 102, 241, 0.12);
+  color: rgba(79, 70, 229, 0.95);
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  display: inline-flex;
+}
+
+.cd-wordcloud-cloud {
   min-height: 180px;
-  padding: 18px;
+  padding: 1.2rem;
   border-radius: 18px;
   border: 1px dashed rgba(99, 102, 241, 0.2);
   background: rgba(255, 255, 255, 0.82);
@@ -1001,19 +1016,41 @@ textarea:focus {
   align-items: center;
 }
 
-.wordcloud-preview-word {
+.cd-wordcloud-word {
   font-weight: 600;
   transition: transform 160ms ease;
+  display: inline-flex;
+  align-items: center;
 }
 
-.wordcloud-preview-word:hover {
+.cd-wordcloud-word:hover {
   transform: translateY(-2px);
 }
 
-.wordcloud-preview-empty {
+.cd-wordcloud-empty {
   margin: 0;
   color: rgba(15, 23, 42, 0.55);
   font-style: italic;
+}
+
+.cd-wordcloud-reset-preview {
+  justify-self: start;
+  margin-top: -0.25rem;
+}
+
+@media (max-width: 640px) {
+  .cd-wordcloud-input {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .cd-wordcloud-input button {
+    width: 100%;
+  }
+
+  .cd-wordcloud-reset-preview {
+    margin-top: 0;
+  }
 }
 
 .debate-preview {


### PR DESCRIPTION
## Summary
- show activity title/description in the live preview shell and refresh those details as they change
- rebuild the word cloud preview to mirror the embed UI, enforce local contribution limits, and share state across renders
- enhance the embed viewer’s resize logic and sync the scripts used in assets and docs

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d8fa05632c832bb72c98823d62cdad