### PR TITLE
Fix embed auto-resize to include bottom margins

### DIFF
--- a/assets/js/embedViewer.js
+++ b/assets/js/embedViewer.js
@@ -318,6 +318,22 @@ const setupAutoResize = (root, container, { embedId } = {}) => {
   const containerEl = container instanceof Element ? container : null;
   let lastHeight = 0;
 
+  const getBottomMargin = (element) => {
+    if (!(element instanceof Element)) {
+      return 0;
+    }
+    try {
+      const style = window.getComputedStyle(element);
+      if (!style) {
+        return 0;
+      }
+      const margin = parseFloat(style.marginBottom);
+      return Number.isFinite(margin) ? margin : 0;
+    } catch (error) {
+      return 0;
+    }
+  };
+
   const measure = () => {
     const body = document.body;
     const doc = document.documentElement;
@@ -339,7 +355,20 @@ const setupAutoResize = (root, container, { embedId } = {}) => {
       return;
     }
 
-    const nextHeight = Math.max(Math.ceil(measured + 16), DEFAULT_MIN_HEIGHT);
+    const marginAdjustments = Math.max(
+      getBottomMargin(root),
+      getBottomMargin(containerEl),
+      getBottomMargin(root?.lastElementChild || null),
+      getBottomMargin(containerEl?.lastElementChild || null)
+    );
+
+    const adjustedHeight = measured + marginAdjustments;
+
+    if (!Number.isFinite(adjustedHeight)) {
+      return;
+    }
+
+    const nextHeight = Math.max(Math.ceil(adjustedHeight + 16), DEFAULT_MIN_HEIGHT);
 
     if (Math.abs(nextHeight - lastHeight) <= 1) {
       return;

--- a/docs/assets/js/embedViewer.js
+++ b/docs/assets/js/embedViewer.js
@@ -318,6 +318,22 @@ const setupAutoResize = (root, container, { embedId } = {}) => {
   const containerEl = container instanceof Element ? container : null;
   let lastHeight = 0;
 
+  const getBottomMargin = (element) => {
+    if (!(element instanceof Element)) {
+      return 0;
+    }
+    try {
+      const style = window.getComputedStyle(element);
+      if (!style) {
+        return 0;
+      }
+      const margin = parseFloat(style.marginBottom);
+      return Number.isFinite(margin) ? margin : 0;
+    } catch (error) {
+      return 0;
+    }
+  };
+
   const measure = () => {
     const body = document.body;
     const doc = document.documentElement;
@@ -339,7 +355,20 @@ const setupAutoResize = (root, container, { embedId } = {}) => {
       return;
     }
 
-    const nextHeight = Math.max(Math.ceil(measured + 16), DEFAULT_MIN_HEIGHT);
+    const marginAdjustments = Math.max(
+      getBottomMargin(root),
+      getBottomMargin(containerEl),
+      getBottomMargin(root?.lastElementChild || null),
+      getBottomMargin(containerEl?.lastElementChild || null)
+    );
+
+    const adjustedHeight = measured + marginAdjustments;
+
+    if (!Number.isFinite(adjustedHeight)) {
+      return;
+    }
+
+    const nextHeight = Math.max(Math.ceil(adjustedHeight + 16), DEFAULT_MIN_HEIGHT);
 
     if (Math.abs(nextHeight - lastHeight) <= 1) {
       return;


### PR DESCRIPTION
## Summary
- account for trailing margins when calculating embed heights so long content is not clipped
- update the published viewer script to keep it in sync with the source version

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9e7b328e4832b9766a15df39ae2bd