### PR TITLE
Fix Canvas embed iframe resizing

### DIFF
--- a/assets/js/embed.js
+++ b/assets/js/embed.js
@@ -65,6 +65,8 @@ const getConfiguredViewerBase = () => {
 };
 
 const VIEWER_URL = new URL('docs/embed.html', getConfiguredViewerBase()).toString();
+const RESIZE_MESSAGE_TYPE = 'canvas-designer:embed-resize';
+const DEFAULT_MIN_HEIGHT = 420;
 
 const sanitizeText = (value, { maxLength = 500 } = {}) => {
   if (typeof value !== 'string') {
@@ -127,6 +129,47 @@ export const generateEmbed = ({ id, type, title, description, data }) => {
   }
 
   const iframeTitle = escapeHtml(safeTitle || activity.label);
+  const viewerOrigin = viewerUrl.origin;
+
+  const resizeScript = `
+(function() {
+  var iframeId = '${embedId}';
+  var minHeight = ${DEFAULT_MIN_HEIGHT};
+  var expectedOrigin = '${viewerOrigin}';
+
+  function applyHeight(value) {
+    var frame = document.getElementById(iframeId);
+    if (!frame) {
+      return;
+    }
+    var numeric = Number(value);
+    if (!(typeof numeric === 'number' && isFinite(numeric))) {
+      numeric = minHeight;
+    }
+    var next = Math.max(Math.ceil(numeric), minHeight);
+    frame.style.height = next + 'px';
+    frame.style.minHeight = next + 'px';
+    frame.style.maxHeight = 'none';
+    frame.style.overflow = 'hidden';
+  }
+
+  applyHeight(minHeight);
+
+  function handleResize(event) {
+    if (!event || !event.data || event.data.type !== '${RESIZE_MESSAGE_TYPE}' || event.data.id !== iframeId) {
+      return;
+    }
+    if (expectedOrigin && event.origin && event.origin !== expectedOrigin) {
+      return;
+    }
+    applyHeight(event.data.height);
+  }
+
+  if (typeof window !== 'undefined' && window.addEventListener) {
+    window.addEventListener('message', handleResize, false);
+  }
+})();
+`.replace(/<\//g, '<\\/');
 
   return `<!-- Canvas Designer Studio embed: ${iframeTitle} -->
 <iframe
@@ -137,7 +180,8 @@ export const generateEmbed = ({ id, type, title, description, data }) => {
   loading="lazy"
   referrerpolicy="no-referrer"
   sandbox="allow-scripts allow-same-origin allow-forms"
-  style="width: 100%; min-height: 420px; border: 0; border-radius: 12px; overflow: hidden; background-color: transparent;"
+  style="width: 100%; min-height: ${DEFAULT_MIN_HEIGHT}px; border: 0; border-radius: 12px; overflow: hidden; background-color: transparent;"
   src="${viewerUrl.toString()}"
-></iframe>`;
+></iframe>
+<script>${resizeScript}</script>`;
 };


### PR DESCRIPTION
## Summary
- inject an inline resize helper alongside the generated iframe so Canvas hosts update the embed height as content changes
- share resize constants with the embed generator to keep the iframe min-height in sync with the viewer

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d9ecaac624832b9220205a6b97a896