### PR TITLE
Ensure embedded activities resize correctly

### DIFF
--- a/assets/js/activities/captionThis.js
+++ b/assets/js/activities/captionThis.js
@@ -933,6 +933,17 @@ const embedTemplate = (data, containerId, context = {}) => {
     if (!root) return;
     const dataNode = root.querySelector('[data-caption-this]');
     if (!dataNode) return;
+
+    const requestResize = () => {
+      try {
+        const api = window.__canvasDesignerEmbed__;
+        if (api && typeof api.requestResize === 'function') {
+          api.requestResize({ immediate: true });
+        }
+      } catch (error) {
+        // Ignore resize errors in restrictive contexts.
+      }
+    };
     let data;
     try {
       data = JSON.parse(dataNode.textContent || '{}');
@@ -1153,6 +1164,7 @@ const embedTemplate = (data, containerId, context = {}) => {
       renderImage();
       renderCaptions();
       updateForm();
+      requestResize();
     };
 
     if (prevButton) {
@@ -1175,6 +1187,12 @@ const embedTemplate = (data, containerId, context = {}) => {
           render();
         }
       });
+    }
+
+    if (imageEl) {
+      const handleImageSettled = () => requestResize();
+      imageEl.addEventListener('load', handleImageSettled);
+      imageEl.addEventListener('error', handleImageSettled);
     }
 
     addButton.addEventListener('click', () => {
@@ -1226,6 +1244,7 @@ const embedTemplate = (data, containerId, context = {}) => {
     });
 
     render();
+    requestResize();
   })();`;
 
   return { html, css, js };

--- a/assets/js/activities/timeline.js
+++ b/assets/js/activities/timeline.js
@@ -583,6 +583,17 @@ const embedTemplate = (data, containerId) => {
       const items = Array.from(root.querySelectorAll('.cd-timeline-item'));
       let activeIndex = -1;
 
+      const requestResize = () => {
+        try {
+          const api = window.__canvasDesignerEmbed__;
+          if (api && typeof api.requestResize === 'function') {
+            api.requestResize({ immediate: true });
+          }
+        } catch (error) {
+          // Ignore resize errors in restrictive contexts.
+        }
+      };
+
       const setActive = (index) => {
         items.forEach((item, itemIndex) => {
           const trigger = item.querySelector('button.cd-timeline-trigger');
@@ -603,6 +614,7 @@ const embedTemplate = (data, containerId) => {
           }
         });
         activeIndex = typeof index === 'number' ? index : -1;
+        requestResize();
       };
 
       items.forEach((item, index) => {
@@ -632,10 +644,12 @@ const embedTemplate = (data, containerId) => {
         if (details) {
           details.style.maxHeight = details.scrollHeight + 'px';
         }
+        requestResize();
       };
 
       window.addEventListener('resize', handleResize);
       setActive(-1);
+      requestResize();
     })();
   `
   };

--- a/docs/assets/js/embedViewer.js
+++ b/docs/assets/js/embedViewer.js
@@ -319,6 +319,9 @@ const setupAutoResize = (root, container, { embedId } = {}) => {
   const containerEl = container instanceof Element ? container : null;
   let lastHeight = 0;
 
+  const globalKey = '__canvasDesignerEmbed__';
+  const globalApi = (window[globalKey] = window[globalKey] || {});
+
   const getBottomMargin = (element) => {
     if (!(element instanceof Element)) {
       return 0;
@@ -377,6 +380,15 @@ const setupAutoResize = (root, container, { embedId } = {}) => {
 
     lastHeight = nextHeight;
     applyFrameHeight(nextHeight, { embedId });
+  };
+
+  globalApi.requestResize = (options = {}) => {
+    const immediate = options.immediate !== false;
+    if (immediate) {
+      measure();
+    } else {
+      window.setTimeout(() => measure(), 0);
+    }
   };
 
   measure();
@@ -467,6 +479,17 @@ const setupAutoResize = (root, container, { embedId } = {}) => {
         fn();
       } catch (error) {
         // Ignore cleanup failures.
+      }
+    }
+
+    if (window[globalKey] === globalApi) {
+      delete globalApi.requestResize;
+      if (Object.keys(globalApi).length === 0) {
+        try {
+          delete window[globalKey];
+        } catch (error) {
+          window[globalKey] = {};
+        }
       }
     }
   };


### PR DESCRIPTION
## Summary
- expose an embed viewer resize API so activities can trigger iframe measurements on demand
- request iframe resizing after dynamic content changes in Caption This embeds to avoid clipped layouts
- ensure Timeline embeds trigger resize updates when expanding or collapsing events

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68da1dec0d58832b8635c83c8be382ab