### PR TITLE
Improve embed sizing and word cloud interactions

### DIFF
--- a/assets/js/embed.js
+++ b/assets/js/embed.js
@@ -69,6 +69,14 @@ const VIEWER_URL = new URL('docs/embed.html', VIEWER_BASE).toString();
 const HOST_SCRIPT_URL = new URL('docs/assets/js/embedHost.js', VIEWER_BASE).toString();
 const DEFAULT_MIN_HEIGHT = 420;
 
+const normaliseHeight = (value) => {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return DEFAULT_MIN_HEIGHT;
+  }
+  return Math.max(Math.ceil(numeric), DEFAULT_MIN_HEIGHT);
+};
+
 const sanitizeText = (value, { maxLength = 500 } = {}) => {
   if (typeof value !== 'string') {
     return '';
@@ -99,7 +107,7 @@ const createViewerUrlWithEmbedId = () => {
   return { url, embedId };
 };
 
-export const generateEmbed = ({ id, type, title, description, data }) => {
+export const generateEmbed = ({ id, type, title, description, data, minHeight }) => {
   const activity = activities[type];
   if (!activity) {
     throw new Error('Unknown activity type');
@@ -131,6 +139,7 @@ export const generateEmbed = ({ id, type, title, description, data }) => {
 
   const iframeTitle = escapeHtml(safeTitle || activity.label);
   const viewerOrigin = viewerUrl.origin;
+  const initialHeight = normaliseHeight(minHeight);
 
   return `<!-- Canvas Designer Studio embed: ${iframeTitle} -->
 <iframe
@@ -143,8 +152,8 @@ export const generateEmbed = ({ id, type, title, description, data }) => {
   sandbox="allow-scripts allow-same-origin allow-forms"
   data-cd-embed-id="${embedId}"
   data-cd-embed-origin="${viewerOrigin}"
-  data-cd-embed-min-height="${DEFAULT_MIN_HEIGHT}"
-  style="width: 100%; min-height: ${DEFAULT_MIN_HEIGHT}px; height: ${DEFAULT_MIN_HEIGHT}px; border: 0; border-radius: 12px; overflow: hidden; background-color: transparent;"
+  data-cd-embed-min-height="${initialHeight}"
+  style="width: 100%; min-height: ${initialHeight}px; height: ${initialHeight}px; border: 0; border-radius: 12px; overflow: hidden; background-color: transparent;"
   src="${viewerUrl.toString()}"
 </iframe>
 <script async src="${HOST_SCRIPT_URL}" data-canvas-designer-embed="true"></script>`;

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -984,6 +984,28 @@ textarea:focus {
   font-weight: 600;
 }
 
+.cd-wordcloud-progress {
+  display: inline-flex;
+  gap: 0.35rem;
+  align-items: center;
+  padding: 0.15rem 0;
+}
+
+.cd-wordcloud-progress-slot {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 999px;
+  background: rgba(99, 102, 241, 0.25);
+  transition: background 160ms ease, transform 160ms ease, opacity 160ms ease;
+  opacity: 0.65;
+}
+
+.cd-wordcloud-progress-slot[data-state='filled'] {
+  background: rgba(79, 70, 229, 0.92);
+  opacity: 1;
+  transform: scale(1.05);
+}
+
 .cd-wordcloud-status {
   margin: 0;
   font-size: 0.9rem;


### PR DESCRIPTION
## Summary
- estimate the preview height when generating embed snippets so iframe code starts closer to the required size
- extend the word cloud preview and embed markup with a remaining submissions indicator and resilient local progress updates
- harden the embedded word cloud client with optimistic updates, local storage clamping, and offline fallback messaging

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68da5edda4f4832b89ba9dbd9053a9d8