### PR TITLE
Fix overlapping inputs in example vs non-example authoring view

### DIFF
--- a/assets/js/activities/exampleNonExample.js
+++ b/assets/js/activities/exampleNonExample.js
@@ -1,0 +1,473 @@
+import { clone, compressImageFile, escapeHtml } from '../utils.js';
+
+const IMAGE_COMPRESSION = {
+  maxWidth: 1600,
+  maxHeight: 1600,
+  quality: 0.82
+};
+
+const ensureColumn = (column = {}, defaults = {}) => {
+  const working = {
+    title: '',
+    description: '',
+    imageUrl: '',
+    altText: '',
+    ...column
+  };
+
+  working.title = typeof working.title === 'string' ? working.title : '';
+  working.description = typeof working.description === 'string' ? working.description : '';
+  working.imageUrl = typeof working.imageUrl === 'string' ? working.imageUrl : '';
+  working.altText = typeof working.altText === 'string' ? working.altText : '';
+
+  if (defaults && typeof defaults === 'object') {
+    working.title = working.title || defaults.title || '';
+    working.description = working.description || defaults.description || '';
+  }
+
+  return working;
+};
+
+const ensureWorkingState = (data = {}) => {
+  const safe = data ? clone(data) : {};
+  return {
+    intro:
+      typeof safe.intro === 'string'
+        ? safe.intro
+        : 'Contrast a strong example with a common misconception so learners can spot the difference quickly.',
+    example: ensureColumn(safe.example),
+    nonExample: ensureColumn(safe.nonExample)
+  };
+};
+
+const template = () =>
+  ensureWorkingState({
+    intro:
+      'Compare a model response with a common pitfall so learners can name the critical differences before they practise.',
+    example: {
+      title: 'Example',
+      description:
+        'Lists a precise claim, cites evidence, and explains why it matters. The structure makes the reasoning easy to follow.',
+      imageUrl:
+        'https://images.unsplash.com/photo-1588072432836-e10032774350?auto=format&fit=crop&w=900&q=80',
+      altText: 'Student presenting a project board covered in sticky notes.'
+    },
+    nonExample: {
+      title: 'Non-example',
+      description:
+        'States the topic but never takes a stance. Lacks evidence and leaves readers unsure what action to take next.',
+      imageUrl:
+        'https://images.unsplash.com/photo-1523580846011-d3a5bc25702b?auto=format&fit=crop&w=900&q=80',
+      altText: 'Students looking uncertain while reviewing a blank flip chart.'
+    }
+  });
+
+const example = () =>
+  ensureWorkingState({
+    intro:
+      'Use this organiser to help facilitators evaluate inquiry proposals. Ask them to annotate the example and non-example with what they notice.',
+    example: {
+      title: 'Example: Insightful driving question',
+      description:
+        '“How can we redesign the library entrance so every student feels welcomed within five seconds?” This version names the audience, defines success, and invites prototyping.',
+      imageUrl:
+        'https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=900&q=80',
+      altText: 'Educator pointing at sticky notes while leading a planning session.'
+    },
+    nonExample: {
+      title: 'Non-example: Vague project idea',
+      description:
+        '“Improve the school library experience.” It is broad, lacks a user to empathise with, and offers no criteria for iteration, making feedback nearly impossible.',
+      imageUrl:
+        'https://images.unsplash.com/photo-1523240795612-9a054b0db644?auto=format&fit=crop&w=900&q=80',
+      altText: 'Group of students appearing unsure while looking at a laptop.'
+    }
+  });
+
+const buildEditor = (container, data, onUpdate) => {
+  const working = ensureWorkingState(data);
+
+  const emit = (refresh = true) => {
+    onUpdate(clone(working));
+    if (refresh) {
+      rerender();
+    }
+  };
+
+  const handleImageUpload = async (key, file) => {
+    if (!file) return;
+    try {
+      const dataUrl = await compressImageFile(file, IMAGE_COMPRESSION);
+      working[key].imageUrl = dataUrl;
+      emit();
+    } catch (error) {
+      console.error('Unable to process uploaded image.', error);
+    }
+  };
+
+  const rerender = () => {
+    container.innerHTML = '';
+
+    const introField = document.createElement('label');
+    introField.className = 'field';
+    introField.innerHTML = '<span class="field-label">General description</span>';
+    const introInput = document.createElement('textarea');
+    introInput.rows = 3;
+    introInput.className = 'text-input';
+    introInput.placeholder = 'Set the scene and tell learners what to compare between the example and non-example.';
+    introInput.value = working.intro;
+    introInput.addEventListener('input', () => {
+      working.intro = introInput.value;
+      emit(false);
+    });
+    introField.append(introInput);
+    container.append(introField);
+
+    const columnsWrapper = document.createElement('div');
+    columnsWrapper.className = 'example-nonexample-editor-grid';
+
+    const buildColumnEditor = (key, label) => {
+      const column = working[key];
+
+      const section = document.createElement('section');
+      section.className = 'example-nonexample-editor-section';
+
+      const heading = document.createElement('h3');
+      heading.className = 'example-nonexample-editor-heading';
+      heading.textContent = label;
+      section.append(heading);
+
+      const titleField = document.createElement('label');
+      titleField.className = 'field';
+      titleField.innerHTML = '<span class="field-label">Headline</span>';
+      const titleInput = document.createElement('input');
+      titleInput.type = 'text';
+      titleInput.className = 'text-input';
+      titleInput.placeholder = label === 'Example' ? 'What makes this an exemplar?' : 'What misconception does this show?';
+      titleInput.value = column.title;
+      titleInput.addEventListener('input', () => {
+        working[key].title = titleInput.value;
+        emit(false);
+      });
+      titleField.append(titleInput);
+      section.append(titleField);
+
+      const descriptionField = document.createElement('label');
+      descriptionField.className = 'field';
+      descriptionField.innerHTML = '<span class="field-label">Supporting details</span>';
+      const descriptionInput = document.createElement('textarea');
+      descriptionInput.rows = 3;
+      descriptionInput.className = 'text-input';
+      descriptionInput.placeholder = 'List the cues that make this a strong or weak example.';
+      descriptionInput.value = column.description;
+      descriptionInput.addEventListener('input', () => {
+        working[key].description = descriptionInput.value;
+        emit(false);
+      });
+      descriptionField.append(descriptionInput);
+      section.append(descriptionField);
+
+      const preview = document.createElement('div');
+      preview.className = 'example-nonexample-editor-preview';
+      if (column.imageUrl) {
+        const image = document.createElement('img');
+        image.src = column.imageUrl;
+        image.alt = '';
+        preview.append(image);
+      } else {
+        const placeholder = document.createElement('div');
+        placeholder.className = 'example-nonexample-editor-placeholder';
+        placeholder.textContent = 'Upload an image to reinforce the comparison.';
+        preview.append(placeholder);
+      }
+      section.append(preview);
+
+      const uploadField = document.createElement('label');
+      uploadField.className = 'field';
+      uploadField.innerHTML = '<span class="field-label">Upload image</span>';
+      const uploadInput = document.createElement('input');
+      uploadInput.type = 'file';
+      uploadInput.accept = 'image/*';
+      uploadInput.className = 'file-input';
+      uploadInput.addEventListener('change', async (event) => {
+        const [file] = event.target.files || [];
+        if (!file) return;
+        await handleImageUpload(key, file);
+        event.target.value = '';
+      });
+      uploadField.append(uploadInput);
+      section.append(uploadField);
+
+      const imageField = document.createElement('label');
+      imageField.className = 'field';
+      imageField.innerHTML = '<span class="field-label">Image URL</span>';
+      const imageInput = document.createElement('input');
+      imageInput.type = 'url';
+      imageInput.className = 'text-input';
+      imageInput.placeholder = 'https://…';
+      imageInput.value = column.imageUrl;
+      imageInput.addEventListener('input', () => {
+        working[key].imageUrl = imageInput.value;
+        emit(false);
+      });
+      imageField.append(imageInput);
+      section.append(imageField);
+
+      const altField = document.createElement('label');
+      altField.className = 'field';
+      altField.innerHTML = '<span class="field-label">Alt text</span>';
+      const altInput = document.createElement('textarea');
+      altInput.rows = 2;
+      altInput.className = 'text-input';
+      altInput.placeholder = 'Describe what matters in this image for non-visual readers.';
+      altInput.value = column.altText;
+      altInput.addEventListener('input', () => {
+        working[key].altText = altInput.value;
+        emit(false);
+      });
+      altField.append(altInput);
+      section.append(altField);
+
+      const removeButton = document.createElement('button');
+      removeButton.type = 'button';
+      removeButton.className = 'muted-button';
+      removeButton.textContent = 'Remove image';
+      removeButton.disabled = !column.imageUrl;
+      removeButton.addEventListener('click', () => {
+        if (!working[key].imageUrl) return;
+        working[key].imageUrl = '';
+        emit();
+      });
+      section.append(removeButton);
+
+      return section;
+    };
+
+    columnsWrapper.append(buildColumnEditor('example', 'Example'));
+    columnsWrapper.append(buildColumnEditor('nonExample', 'Non-example'));
+    container.append(columnsWrapper);
+  };
+
+  rerender();
+};
+
+const createColumnPreview = (column, label) => {
+  const article = document.createElement('article');
+  article.className = `example-nonexample-column ${label === 'Example' ? 'is-example' : 'is-nonexample'}`;
+
+  const tag = document.createElement('span');
+  tag.className = 'example-nonexample-tag';
+  tag.textContent = label;
+  article.append(tag);
+
+  if (column.title) {
+    const heading = document.createElement('h4');
+    heading.className = 'example-nonexample-title';
+    heading.textContent = column.title;
+    article.append(heading);
+  }
+
+  if (column.imageUrl) {
+    const figure = document.createElement('figure');
+    figure.className = 'example-nonexample-figure';
+    const image = document.createElement('img');
+    image.src = column.imageUrl;
+    image.alt = column.altText || '';
+    figure.append(image);
+    article.append(figure);
+  }
+
+  const description = document.createElement('p');
+  description.className = 'example-nonexample-description';
+  if (column.description) {
+    description.textContent = column.description;
+  } else {
+    description.classList.add('is-placeholder');
+    description.textContent =
+      label === 'Example'
+        ? 'Describe why this example succeeds so learners can replicate the move.'
+        : 'Explain the misconception so learners know what to avoid.';
+  }
+  article.append(description);
+
+  return article;
+};
+
+const renderPreview = (container, data) => {
+  const working = ensureWorkingState(data);
+  container.innerHTML = '';
+
+  const section = document.createElement('section');
+  section.className = 'example-nonexample-preview';
+
+  if (working.intro) {
+    const intro = document.createElement('p');
+    intro.className = 'example-nonexample-intro';
+    intro.textContent = working.intro;
+    section.append(intro);
+  }
+
+  const grid = document.createElement('div');
+  grid.className = 'example-nonexample-grid';
+  grid.append(createColumnPreview(working.example, 'Example'));
+  grid.append(createColumnPreview(working.nonExample, 'Non-example'));
+
+  section.append(grid);
+  container.append(section);
+};
+
+const embedTemplate = (data, containerId) => {
+  const working = ensureWorkingState(data);
+
+  const columnHtml = (column, label) => `
+    <article class="cd-example-nonexample-column ${
+      label === 'Example' ? 'is-example' : 'is-nonexample'
+    }">
+      <span class="cd-example-nonexample-tag">${escapeHtml(label)}</span>
+      ${column.title ? `<h4 class="cd-example-nonexample-title">${escapeHtml(column.title)}</h4>` : ''}
+      ${
+        column.imageUrl
+          ? `<figure class="cd-example-nonexample-figure"><img src="${escapeHtml(column.imageUrl)}" alt="${escapeHtml(
+              column.altText || ''
+            )}" /></figure>`
+          : ''
+      }
+      <p class="cd-example-nonexample-description">${escapeHtml(
+        column.description ||
+          (label === 'Example'
+            ? 'Describe why this example succeeds so learners can replicate the move.'
+            : 'Explain the misconception so learners know what to avoid.')
+      )}</p>
+    </article>
+  `;
+
+  return {
+    html: `
+      <section class="cd-example-nonexample" aria-label="Example and non-example comparison">
+        ${
+          working.intro
+            ? `<p class="cd-example-nonexample-intro">${escapeHtml(working.intro)}</p>`
+            : ''
+        }
+        <div class="cd-example-nonexample-grid">
+          ${columnHtml(working.example, 'Example')}
+          ${columnHtml(working.nonExample, 'Non-example')}
+        </div>
+      </section>
+    `,
+    css: `
+      #${containerId} .cd-example-nonexample {
+        display: grid;
+        gap: 1.25rem;
+        padding: 1.5rem;
+        border-radius: 18px;
+        background: linear-gradient(135deg, rgba(59, 130, 246, 0.08), rgba(16, 185, 129, 0.08));
+        border: 1px solid rgba(59, 130, 246, 0.18);
+      }
+      #${containerId} .cd-example-nonexample-intro {
+        margin: 0;
+        font-size: 1rem;
+        line-height: 1.6;
+        color: rgba(15, 23, 42, 0.85);
+      }
+      #${containerId} .cd-example-nonexample-grid {
+        display: grid;
+        gap: 1rem;
+      }
+      @media (min-width: 760px) {
+        #${containerId} .cd-example-nonexample-grid {
+          grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+      }
+      #${containerId} .cd-example-nonexample-column {
+        position: relative;
+        display: grid;
+        gap: 0.75rem;
+        padding: 1.25rem;
+        border-radius: 16px;
+        background: rgba(255, 255, 255, 0.95);
+        border: 1px solid rgba(148, 163, 184, 0.45);
+        box-shadow: 0 16px 32px rgba(15, 23, 42, 0.08);
+      }
+      #${containerId} .cd-example-nonexample-column.is-example {
+        border-color: rgba(16, 185, 129, 0.45);
+      }
+      #${containerId} .cd-example-nonexample-column.is-nonexample {
+        border-color: rgba(239, 68, 68, 0.4);
+      }
+      #${containerId} .cd-example-nonexample-tag {
+        display: inline-flex;
+        align-self: flex-start;
+        align-items: center;
+        gap: 0.35rem;
+        padding: 0.25rem 0.65rem;
+        border-radius: 999px;
+        font-size: 0.8rem;
+        font-weight: 600;
+        letter-spacing: 0.02em;
+        background: rgba(59, 130, 246, 0.15);
+        color: rgba(30, 64, 175, 0.95);
+      }
+      #${containerId} .cd-example-nonexample-column.is-example .cd-example-nonexample-tag {
+        background: rgba(16, 185, 129, 0.18);
+        color: rgba(6, 95, 70, 0.95);
+      }
+      #${containerId} .cd-example-nonexample-column.is-nonexample .cd-example-nonexample-tag {
+        background: rgba(239, 68, 68, 0.18);
+        color: rgba(153, 27, 27, 0.95);
+      }
+      #${containerId} .cd-example-nonexample-title {
+        margin: 0;
+        font-size: 1.05rem;
+        font-weight: 600;
+        color: rgba(15, 23, 42, 0.9);
+      }
+      #${containerId} .cd-example-nonexample-figure {
+        margin: 0;
+        border-radius: 14px;
+        overflow: hidden;
+      }
+      #${containerId} .cd-example-nonexample-figure img {
+        display: block;
+        width: 100%;
+        height: auto;
+      }
+      #${containerId} .cd-example-nonexample-description {
+        margin: 0;
+        font-size: 0.95rem;
+        line-height: 1.6;
+        color: rgba(30, 41, 59, 0.85);
+      }
+    `,
+    js: ''
+  };
+};
+
+const learningTip = {
+  intro:
+    'Placing an example beside a non-example spotlights the criteria that matter most, helping learners diagnose quality before they practise.',
+  when:
+    'Use this when introducing rubrics, feedback guides, or problem-solving heuristics so students can immediately contrast strong and weak moves.',
+  considerations: [
+    'Annotate each column with the cues you want learners to notice, then ask them to add their own observations.',
+    'Invite learners to predict how they would revise the non-example before revealing your reasoning.',
+    'Encourage reflection: What patterns do they see across the examples collected over the term?'
+  ],
+  examples: [
+    'Writing workshop: compare thesis statements before students craft their own claims.',
+    'STEM lab: show a correctly labelled diagram beside one missing critical annotations.',
+    'Facilitator training: contrast a strong discussion prompt with one that stalls participation.'
+  ]
+};
+
+export const exampleNonExample = {
+  id: 'exampleNonExample',
+  label: 'Examples vs non-examples',
+  template,
+  example,
+  buildEditor,
+  renderPreview,
+  embedTemplate,
+  learningTip
+};
+

--- a/assets/js/activities/index.js
+++ b/assets/js/activities/index.js
@@ -9,6 +9,7 @@ import { immersiveText } from './immersiveText.js';
 import { wordCloud } from './wordCloud.js';
 import { debate } from './debate.js';
 import { captionThis } from './captionThis.js';
+import { exampleNonExample } from './exampleNonExample.js';
 
 export const activities = {
   [flipCards.id]: flipCards,
@@ -21,7 +22,8 @@ export const activities = {
   [immersiveText.id]: immersiveText,
   [wordCloud.id]: wordCloud,
   [debate.id]: debate,
-  [captionThis.id]: captionThis
+  [captionThis.id]: captionThis,
+  [exampleNonExample.id]: exampleNonExample
 };
 
 export const defaultActivityId = flipCards.id;

--- a/assets/js/activityCatalog.js
+++ b/assets/js/activityCatalog.js
@@ -1,0 +1,74 @@
+export const activityCatalog = [
+  {
+    id: 'flipCards',
+    label: 'Flip cards',
+    icon: '🃏',
+    description: 'Reveal concise explanations or definitions to reinforce core concepts quickly.'
+  },
+  {
+    id: 'accordion',
+    label: 'Accordion',
+    icon: '📚',
+    description: 'Layer supporting details beneath headings so learners can explore at their own pace.'
+  },
+  {
+    id: 'timeline',
+    label: 'Timeline',
+    icon: '🗓️',
+    description: 'Showcase milestones or process steps with rich media context along a horizontal path.'
+  },
+  {
+    id: 'wordCloud',
+    label: 'Word cloud',
+    icon: '☁️',
+    description: 'Collect brainstormed ideas or reflections and visualise the most common themes.'
+  },
+  {
+    id: 'dragDrop',
+    label: 'Drag & Drop',
+    icon: '🧩',
+    description: 'Let learners sort, match, or categorise items to demonstrate understanding of relationships.'
+  },
+  {
+    id: 'hotspots',
+    label: 'Hotspots',
+    icon: '📍',
+    description: 'Layer interactive markers over an image so students can inspect crucial details.'
+  },
+  {
+    id: 'immersiveText',
+    label: 'Immersive text',
+    icon: '🪄',
+    description: 'Embed questions, media, and callouts directly inside readings to guide attention.'
+  },
+  {
+    id: 'branchingScenarios',
+    label: 'Branching scenarios',
+    icon: '🧠',
+    description: 'Create choose-your-path decision stories that surface consequences of each choice.'
+  },
+  {
+    id: 'imageCarousel',
+    label: 'Image carousel',
+    icon: '🖼️',
+    description: 'Sequence visuals with captions to walk learners through a process or gallery.'
+  },
+  {
+    id: 'captionThis',
+    label: 'Caption this',
+    icon: '✍️',
+    description: 'Invite learners to compose captions that connect imagery back to course outcomes.'
+  },
+  {
+    id: 'debate',
+    label: 'Structured debate',
+    icon: '⚖️',
+    description: 'Stage opposing viewpoints and gather arguments to analyse evidence and reasoning.'
+  },
+  {
+    id: 'exampleNonExample',
+    label: 'Examples vs non-examples',
+    icon: '✅❌',
+    description: 'Contrast a model response with a common misconception in a side-by-side layout.'
+  }
+];

--- a/assets/styles/main.css
+++ b/assets/styles/main.css
@@ -3079,6 +3079,276 @@ textarea:focus {
   animation-delay: 160ms;
 }
 
+.example-nonexample-preview {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.example-nonexample-intro {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.65;
+  color: rgba(15, 23, 42, 0.72);
+}
+
+.example-nonexample-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+@media (min-width: 960px) {
+  .example-nonexample-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.example-nonexample-column {
+  display: grid;
+  gap: 0.75rem;
+  padding: 1.25rem;
+  border-radius: 18px;
+  background: linear-gradient(145deg, rgba(255, 255, 255, 0.95), rgba(241, 245, 249, 0.92));
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  box-shadow: 0 16px 32px rgba(15, 23, 42, 0.08);
+}
+
+.example-nonexample-column.is-example {
+  border-color: rgba(16, 185, 129, 0.38);
+}
+
+.example-nonexample-column.is-nonexample {
+  border-color: rgba(239, 68, 68, 0.32);
+}
+
+.example-nonexample-tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.3rem 0.7rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  background: rgba(59, 130, 246, 0.18);
+  color: rgba(30, 64, 175, 0.92);
+  width: fit-content;
+}
+
+.example-nonexample-column.is-example .example-nonexample-tag {
+  background: rgba(16, 185, 129, 0.2);
+  color: rgba(6, 95, 70, 0.92);
+}
+
+.example-nonexample-column.is-nonexample .example-nonexample-tag {
+  background: rgba(239, 68, 68, 0.18);
+  color: rgba(153, 27, 27, 0.92);
+}
+
+.example-nonexample-title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.9);
+}
+
+.example-nonexample-figure {
+  margin: 0;
+  border-radius: 16px;
+  overflow: hidden;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.12);
+}
+
+.example-nonexample-figure img {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.example-nonexample-description {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: rgba(30, 41, 59, 0.85);
+}
+
+.example-nonexample-description.is-placeholder {
+  font-style: italic;
+  color: rgba(30, 41, 59, 0.6);
+}
+
+.example-nonexample-editor-grid {
+  display: grid;
+  gap: 1.5rem;
+  margin-top: 1.5rem;
+}
+
+@media (min-width: 960px) {
+  .example-nonexample-editor-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.example-nonexample-editor-section {
+  display: grid;
+  gap: 1rem;
+  padding: 1.25rem;
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(248, 250, 252, 0.88);
+}
+
+.example-nonexample-editor-section .field {
+  min-width: 0;
+}
+
+.example-nonexample-editor-section .field > .text-input,
+.example-nonexample-editor-section .field > .file-input {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.example-nonexample-editor-heading {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.85);
+}
+
+.example-nonexample-editor-preview {
+  border: 1px dashed rgba(148, 163, 184, 0.6);
+  border-radius: 16px;
+  min-height: 160px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(255, 255, 255, 0.7);
+  overflow: hidden;
+}
+
+.example-nonexample-editor-preview img {
+  width: 100%;
+  height: auto;
+  display: block;
+}
+
+.example-nonexample-editor-placeholder {
+  font-size: 0.95rem;
+  color: rgba(71, 85, 105, 0.8);
+  text-align: center;
+  padding: 0 12px;
+}
+
+.discover-modal {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 32px;
+  z-index: 60;
+}
+
+.discover-modal[data-open='true'] {
+  display: flex;
+}
+
+.discover-modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  backdrop-filter: blur(4px);
+}
+
+.discover-modal-dialog {
+  position: relative;
+  width: min(940px, 100%);
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 28px 28px 24px;
+  border-radius: 24px;
+  background: linear-gradient(160deg, rgba(255, 255, 255, 0.96), rgba(226, 232, 240, 0.94));
+  box-shadow: 0 32px 64px rgba(15, 23, 42, 0.28);
+  overflow: hidden;
+}
+
+.discover-modal-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.discover-modal-body {
+  overflow: auto;
+  padding-right: 8px;
+}
+
+.discover-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.discover-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+  padding: 18px;
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+  text-align: left;
+  cursor: pointer;
+  transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease;
+  width: 100%;
+}
+
+.discover-card:hover,
+.discover-card:focus-visible {
+  transform: translateY(-2px);
+  border-color: rgba(59, 130, 246, 0.45);
+  box-shadow: 0 18px 30px rgba(37, 99, 235, 0.18);
+  outline: none;
+}
+
+.discover-card.is-active {
+  border-color: rgba(16, 185, 129, 0.6);
+  box-shadow: 0 18px 36px rgba(16, 185, 129, 0.18);
+}
+
+.discover-card-icon {
+  font-size: 1.8rem;
+  line-height: 1;
+}
+
+.discover-card-content {
+  display: grid;
+  gap: 6px;
+}
+
+.discover-card-title {
+  font-size: 1rem;
+  font-weight: 600;
+  color: rgba(15, 23, 42, 0.88);
+}
+
+.discover-card-description {
+  font-size: 0.92rem;
+  line-height: 1.5;
+  color: rgba(71, 85, 105, 0.9);
+}
+
+.discover-grid:empty::before {
+  content: 'Loading activities…';
+  display: block;
+  text-align: center;
+  padding: 32px 0;
+  color: rgba(71, 85, 105, 0.8);
+}
+
 @keyframes cd-immersive-pop {
   from {
     opacity: 0;
@@ -3237,6 +3507,47 @@ textarea:focus {
   .hotspot-popover {
     width: min(320px, calc(100vw - 32px));
     min-width: auto;
+  }
+
+  .example-nonexample-column {
+    padding: 1rem;
+  }
+
+  .example-nonexample-editor-section {
+    padding: 1rem;
+  }
+
+  .example-nonexample-editor-preview {
+    min-height: 140px;
+  }
+
+  .discover-modal {
+    padding: 16px;
+    align-items: flex-end;
+  }
+
+  .discover-modal-dialog {
+    width: 100%;
+    max-height: 88vh;
+    padding: 24px 20px 20px;
+    border-radius: 20px;
+  }
+
+  .discover-modal-body {
+    padding-right: 0;
+  }
+
+  .discover-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .discover-card {
+    gap: 12px;
+    padding: 16px;
+  }
+
+  .discover-card-icon {
+    font-size: 1.5rem;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -22,6 +22,7 @@
         </div>
         <div class="header-actions">
           <button id="newProjectBtn" class="ghost-button" type="button">New activity</button>
+          <button id="discoverActivitiesBtn" class="ghost-button" type="button">Discover activities</button>
           <button class="ghost-button" type="button" data-preview-toggle="true" aria-pressed="false">
             Hide preview
           </button>
@@ -56,6 +57,7 @@
                   <option value="branchingScenarios">Branching scenarios</option>
                   <option value="imageCarousel">Image carousel</option>
                   <option value="captionThis">Caption this</option>
+                  <option value="exampleNonExample">Examples vs non-examples</option>
                   <option value="debate">Structured debate</option>
                 </select>
                 <span class="activity-picker-icon" aria-hidden="true"></span>
@@ -148,6 +150,39 @@
           </div>
         </section>
       </main>
+    </div>
+
+    <div id="discoverPanel" class="discover-modal" data-open="false" aria-hidden="true">
+      <div class="discover-modal-backdrop" data-discover-dismiss="true" aria-hidden="true"></div>
+      <div
+        id="discoverDialog"
+        class="discover-modal-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="discoverTitle"
+        aria-describedby="discoverDescription"
+        tabindex="-1"
+      >
+        <div class="discover-modal-header">
+          <div>
+            <h2 id="discoverTitle" class="panel-title">Discover activities</h2>
+            <p id="discoverDescription" class="hint">
+              Browse every template, preview its purpose, and jump straight into creating.
+            </p>
+          </div>
+          <button
+            id="discoverCloseBtn"
+            class="ghost-button modal-close"
+            type="button"
+            aria-label="Close discover panel"
+          >
+            Close
+          </button>
+        </div>
+        <div class="discover-modal-body">
+          <div id="discoverList" class="discover-grid" role="list"></div>
+        </div>
+      </div>
     </div>
 
     <div id="embedModal" class="modal" data-open="false" aria-hidden="true">


### PR DESCRIPTION
## Summary
- apply standard form field styles to example vs non-example authoring inputs so they size consistently
- constrain the editor column layout to keep stacked fields from overlapping and maintain full-width controls

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dc732955f4832b922864e19d47f0e0