### PR TITLE
Fix missing word cloud inputs in embed viewer

### DIFF
--- a/assets/js/activities/wordCloud.js
+++ b/assets/js/activities/wordCloud.js
@@ -1307,7 +1307,8 @@ const embedTemplate = (data, containerId, context = {}) => {
         }
       });
     })();
-  `
+  `,
+    module: true
   };
 };
 

--- a/assets/js/embedViewer.js
+++ b/assets/js/embedViewer.js
@@ -511,6 +511,9 @@ const renderActivity = (root, payload, { embedId } = {}) => {
 
   if (parts.js) {
     const script = document.createElement('script');
+    if (parts.module) {
+      script.type = 'module';
+    }
     script.textContent = parts.js;
     document.body.append(script);
   }

--- a/docs/assets/js/activities/wordCloud.js
+++ b/docs/assets/js/activities/wordCloud.js
@@ -1307,7 +1307,8 @@ const embedTemplate = (data, containerId, context = {}) => {
         }
       });
     })();
-  `
+  `,
+    module: true
   };
 };
 

--- a/docs/assets/js/embedViewer.js
+++ b/docs/assets/js/embedViewer.js
@@ -549,6 +549,9 @@ const renderActivity = (root, payload, { embedId } = {}) => {
 
   if (parts.js) {
     const script = document.createElement('script');
+    if (parts.module) {
+      script.type = 'module';
+    }
     script.textContent = parts.js;
     document.body.append(script);
   }


### PR DESCRIPTION
## Summary
- mark the word cloud embed template as a module script so it can run dynamic imports
- update the embed viewer to execute module scripts, restoring the word submission inputs in the embed

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dcc24b856c832b954ae95d7734b118