### PR TITLE
Fix word cloud embed script quoting

### DIFF
--- a/assets/js/activities/wordCloud.js
+++ b/assets/js/activities/wordCloud.js
@@ -1134,7 +1134,7 @@ const embedTemplate = (data, containerId, context = {}) => {
         }
         submitButton.disabled = !activeInput;
         if (!activeInput) {
-          showStatus('Thanks! You\'ve used all your contributions on this device.', 'limit');
+          showStatus("Thanks! You've used all your contributions on this device.", 'limit');
         } else if (!statusEl.hidden && statusEl.dataset.tone === 'limit') {
           clearStatus();
         }
@@ -1307,7 +1307,8 @@ const embedTemplate = (data, containerId, context = {}) => {
         }
       });
     })();
-  `
+  `,
+    module: true
   };
 };
 

--- a/assets/js/embedViewer.js
+++ b/assets/js/embedViewer.js
@@ -511,6 +511,9 @@ const renderActivity = (root, payload, { embedId } = {}) => {
 
   if (parts.js) {
     const script = document.createElement('script');
+    if (parts.module) {
+      script.type = 'module';
+    }
     script.textContent = parts.js;
     document.body.append(script);
   }

--- a/docs/assets/js/activities/wordCloud.js
+++ b/docs/assets/js/activities/wordCloud.js
@@ -1134,7 +1134,7 @@ const embedTemplate = (data, containerId, context = {}) => {
         }
         submitButton.disabled = !activeInput;
         if (!activeInput) {
-          showStatus('Thanks! You\'ve used all your contributions on this device.', 'limit');
+          showStatus("Thanks! You've used all your contributions on this device.", 'limit');
         } else if (!statusEl.hidden && statusEl.dataset.tone === 'limit') {
           clearStatus();
         }
@@ -1307,7 +1307,8 @@ const embedTemplate = (data, containerId, context = {}) => {
         }
       });
     })();
-  `
+  `,
+    module: true
   };
 };
 

--- a/docs/assets/js/embedViewer.js
+++ b/docs/assets/js/embedViewer.js
@@ -549,6 +549,9 @@ const renderActivity = (root, payload, { embedId } = {}) => {
 
   if (parts.js) {
     const script = document.createElement('script');
+    if (parts.module) {
+      script.type = 'module';
+    }
     script.textContent = parts.js;
     document.body.append(script);
   }


### PR DESCRIPTION
## Summary
- update the word cloud embed script to use double-quoted status text so apostrophes no longer break inline modules
- mirror the same fix in the documentation build to keep embeds consistent

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dcc24b856c832b954ae95d7734b118