### PR TITLE
Load embed activity scripts via blob URLs

### DIFF
--- a/assets/js/activities/wordCloud.js
+++ b/assets/js/activities/wordCloud.js
@@ -1134,7 +1134,7 @@ const embedTemplate = (data, containerId, context = {}) => {
         }
         submitButton.disabled = !activeInput;
         if (!activeInput) {
-          showStatus('Thanks! You\'ve used all your contributions on this device.', 'limit');
+          showStatus("Thanks! You've used all your contributions on this device.", 'limit');
         } else if (!statusEl.hidden && statusEl.dataset.tone === 'limit') {
           clearStatus();
         }
@@ -1307,7 +1307,8 @@ const embedTemplate = (data, containerId, context = {}) => {
         }
       });
     })();
-  `
+  `,
+    module: true
   };
 };
 

--- a/docs/assets/js/activities/wordCloud.js
+++ b/docs/assets/js/activities/wordCloud.js
@@ -1134,7 +1134,7 @@ const embedTemplate = (data, containerId, context = {}) => {
         }
         submitButton.disabled = !activeInput;
         if (!activeInput) {
-          showStatus('Thanks! You\'ve used all your contributions on this device.', 'limit');
+          showStatus("Thanks! You've used all your contributions on this device.", 'limit');
         } else if (!statusEl.hidden && statusEl.dataset.tone === 'limit') {
           clearStatus();
         }
@@ -1307,7 +1307,8 @@ const embedTemplate = (data, containerId, context = {}) => {
         }
       });
     })();
-  `
+  `,
+    module: true
   };
 };
 

--- a/docs/assets/js/embedViewer.js
+++ b/docs/assets/js/embedViewer.js
@@ -548,9 +548,53 @@ const renderActivity = (root, payload, { embedId } = {}) => {
   document.head.append(style);
 
   if (parts.js) {
-    const script = document.createElement('script');
-    script.textContent = parts.js;
-    document.body.append(script);
+    const cleanupUrl = (url) => {
+      try {
+        URL.revokeObjectURL(url);
+      } catch (error) {
+        // Ignore cleanup failures.
+      }
+    };
+
+    const appendInlineScript = () => {
+      const script = document.createElement('script');
+      if (parts.module) {
+        script.type = 'module';
+      }
+      script.textContent = parts.js;
+      document.body.append(script);
+    };
+
+    try {
+      if (typeof Blob === 'function' && typeof URL?.createObjectURL === 'function') {
+        const blob = new Blob([parts.js], { type: 'text/javascript' });
+        const blobUrl = URL.createObjectURL(blob);
+
+        if (parts.module) {
+          import(blobUrl)
+            .catch((error) => {
+              console.error('Failed to execute module activity script', error);
+            })
+            .finally(() => cleanupUrl(blobUrl));
+        } else {
+          const script = document.createElement('script');
+          if (parts.module) {
+            script.type = 'module';
+          }
+          script.src = blobUrl;
+          script.async = false;
+          const handleDone = () => cleanupUrl(blobUrl);
+          script.addEventListener('load', handleDone, { once: true });
+          script.addEventListener('error', handleDone, { once: true });
+          document.body.append(script);
+        }
+      } else {
+        appendInlineScript();
+      }
+    } catch (error) {
+      console.error('Failed to inject activity script', error);
+      appendInlineScript();
+    }
   }
 
   setupAutoResize(root, container, { embedId });


### PR DESCRIPTION
## Summary
- load embed activity scripts via blob URLs so browsers with restrictive inline script policies (like Canvas LMS) still run the word cloud inputs
- fall back to the previous inline execution path if the blob approach fails or APIs are unavailable
- mirror the same viewer update in the documentation bundle

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dcc24b856c832b954ae95d7734b118