### PR TITLE
Load embed scripts via blob URLs

### DIFF
--- a/assets/js/activities/wordCloud.js
+++ b/assets/js/activities/wordCloud.js
@@ -1134,7 +1134,7 @@ const embedTemplate = (data, containerId, context = {}) => {
         }
         submitButton.disabled = !activeInput;
         if (!activeInput) {
-          showStatus('Thanks! You\'ve used all your contributions on this device.', 'limit');
+          showStatus("Thanks! You've used all your contributions on this device.", 'limit');
         } else if (!statusEl.hidden && statusEl.dataset.tone === 'limit') {
           clearStatus();
         }
@@ -1307,7 +1307,8 @@ const embedTemplate = (data, containerId, context = {}) => {
         }
       });
     })();
-  `
+  `,
+    module: true
   };
 };
 

--- a/docs/assets/js/activities/wordCloud.js
+++ b/docs/assets/js/activities/wordCloud.js
@@ -1134,7 +1134,7 @@ const embedTemplate = (data, containerId, context = {}) => {
         }
         submitButton.disabled = !activeInput;
         if (!activeInput) {
-          showStatus('Thanks! You\'ve used all your contributions on this device.', 'limit');
+          showStatus("Thanks! You've used all your contributions on this device.", 'limit');
         } else if (!statusEl.hidden && statusEl.dataset.tone === 'limit') {
           clearStatus();
         }
@@ -1307,7 +1307,8 @@ const embedTemplate = (data, containerId, context = {}) => {
         }
       });
     })();
-  `
+  `,
+    module: true
   };
 };
 

--- a/docs/assets/js/embedViewer.js
+++ b/docs/assets/js/embedViewer.js
@@ -548,9 +548,70 @@ const renderActivity = (root, payload, { embedId } = {}) => {
   document.head.append(style);
 
   if (parts.js) {
-    const script = document.createElement('script');
-    script.textContent = parts.js;
-    document.body.append(script);
+    const appendInlineScript = () => {
+      try {
+        const inlineScript = document.createElement('script');
+        if (parts.module) {
+          inlineScript.type = 'module';
+        } else if ('async' in inlineScript) {
+          inlineScript.async = false;
+        }
+        inlineScript.textContent = parts.js;
+        document.body.append(inlineScript);
+      } catch (error) {
+        console.error('Failed to append activity script element', error);
+      }
+    };
+
+    try {
+      if (typeof Blob === 'function' && typeof URL?.createObjectURL === 'function') {
+        const blob = new Blob([parts.js], { type: 'text/javascript' });
+        const blobUrl = URL.createObjectURL(blob);
+
+        const script = document.createElement('script');
+        if (parts.module) {
+          script.type = 'module';
+        } else if ('async' in script) {
+          script.async = false;
+        }
+        script.src = blobUrl;
+
+        const cleanup = () => {
+          try {
+            URL.revokeObjectURL(blobUrl);
+          } catch (error) {
+            // Ignore cleanup failures.
+          }
+        };
+
+        script.addEventListener(
+          'load',
+          () => {
+            cleanup();
+          },
+          { once: true }
+        );
+
+        script.addEventListener(
+          'error',
+          (event) => {
+            cleanup();
+            if (event?.type === 'error') {
+              console.error('Failed to execute activity script from blob URL', event);
+              appendInlineScript();
+            }
+          },
+          { once: true }
+        );
+
+        document.body.append(script);
+      } else {
+        appendInlineScript();
+      }
+    } catch (error) {
+      console.error('Failed to inject activity script', error);
+      appendInlineScript();
+    }
   }
 
   setupAutoResize(root, container, { embedId });


### PR DESCRIPTION
## Summary
- execute embed activity scripts from Blob URLs when supported so Canvas LMS can run module code despite inline script restrictions
- fall back to inline script injection with async guards and detailed logging, mirroring the behavior in the documentation embed viewer

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dcc24b856c832b954ae95d7734b118