### PR TITLE
Mark word cloud embed scripts as modules

### DIFF
--- a/assets/js/activities/wordCloud.js
+++ b/assets/js/activities/wordCloud.js
@@ -959,6 +959,7 @@ const embedTemplate = (data, containerId, context = {}) => {
       }
     }
   `,
+    module: true,
     js: `
     (() => {
       const config = ${serializeForScript(config)};
@@ -1134,7 +1135,7 @@ const embedTemplate = (data, containerId, context = {}) => {
         }
         submitButton.disabled = !activeInput;
         if (!activeInput) {
-          showStatus('Thanks! You\'ve used all your contributions on this device.', 'limit');
+          showStatus("Thanks! You've used all your contributions on this device.", 'limit');
         } else if (!statusEl.hidden && statusEl.dataset.tone === 'limit') {
           clearStatus();
         }

--- a/assets/js/embedViewer.js
+++ b/assets/js/embedViewer.js
@@ -510,9 +510,18 @@ const renderActivity = (root, payload, { embedId } = {}) => {
   document.head.append(style);
 
   if (parts.js) {
-    const script = document.createElement('script');
-    script.textContent = parts.js;
-    document.body.append(script);
+    try {
+      const script = document.createElement('script');
+      if (parts.module) {
+        script.type = 'module';
+      } else if ('async' in script) {
+        script.async = false;
+      }
+      script.textContent = parts.js;
+      document.body.append(script);
+    } catch (error) {
+      console.error('Failed to append activity script element', error);
+    }
   }
 
   setupAutoResize(root, container, { embedId });

--- a/docs/assets/js/activities/wordCloud.js
+++ b/docs/assets/js/activities/wordCloud.js
@@ -959,6 +959,7 @@ const embedTemplate = (data, containerId, context = {}) => {
       }
     }
   `,
+    module: true,
     js: `
     (() => {
       const config = ${serializeForScript(config)};
@@ -1134,7 +1135,7 @@ const embedTemplate = (data, containerId, context = {}) => {
         }
         submitButton.disabled = !activeInput;
         if (!activeInput) {
-          showStatus('Thanks! You\'ve used all your contributions on this device.', 'limit');
+          showStatus("Thanks! You've used all your contributions on this device.", 'limit');
         } else if (!statusEl.hidden && statusEl.dataset.tone === 'limit') {
           clearStatus();
         }

--- a/docs/assets/js/embedViewer.js
+++ b/docs/assets/js/embedViewer.js
@@ -548,9 +548,18 @@ const renderActivity = (root, payload, { embedId } = {}) => {
   document.head.append(style);
 
   if (parts.js) {
-    const script = document.createElement('script');
-    script.textContent = parts.js;
-    document.body.append(script);
+    try {
+      const script = document.createElement('script');
+      if (parts.module) {
+        script.type = 'module';
+      } else if ('async' in script) {
+        script.async = false;
+      }
+      script.textContent = parts.js;
+      document.body.append(script);
+    } catch (error) {
+      console.error('Failed to append activity script element', error);
+    }
   }
 
   setupAutoResize(root, container, { embedId });


### PR DESCRIPTION
## Summary
- mark the word cloud embed template payload so the viewer injects the script as a module
- mirror the module flag in the docs bundle to keep the preview build in sync

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dcc24b856c832b954ae95d7734b118