### PR TITLE
Load embed activity scripts via blob URLs

### DIFF
--- a/assets/js/activities/wordCloud.js
+++ b/assets/js/activities/wordCloud.js
@@ -959,6 +959,7 @@ const embedTemplate = (data, containerId, context = {}) => {
       }
     }
   `,
+    module: true,
     js: `
     (() => {
       const config = ${serializeForScript(config)};
@@ -1134,7 +1135,7 @@ const embedTemplate = (data, containerId, context = {}) => {
         }
         submitButton.disabled = !activeInput;
         if (!activeInput) {
-          showStatus('Thanks! You\'ve used all your contributions on this device.', 'limit');
+          showStatus("Thanks! You've used all your contributions on this device.", 'limit');
         } else if (!statusEl.hidden && statusEl.dataset.tone === 'limit') {
           clearStatus();
         }

--- a/docs/assets/js/activities/wordCloud.js
+++ b/docs/assets/js/activities/wordCloud.js
@@ -959,6 +959,7 @@ const embedTemplate = (data, containerId, context = {}) => {
       }
     }
   `,
+    module: true,
     js: `
     (() => {
       const config = ${serializeForScript(config)};
@@ -1134,7 +1135,7 @@ const embedTemplate = (data, containerId, context = {}) => {
         }
         submitButton.disabled = !activeInput;
         if (!activeInput) {
-          showStatus('Thanks! You\'ve used all your contributions on this device.', 'limit');
+          showStatus("Thanks! You've used all your contributions on this device.", 'limit');
         } else if (!statusEl.hidden && statusEl.dataset.tone === 'limit') {
           clearStatus();
         }

--- a/docs/assets/js/embedViewer.js
+++ b/docs/assets/js/embedViewer.js
@@ -548,9 +548,70 @@ const renderActivity = (root, payload, { embedId } = {}) => {
   document.head.append(style);
 
   if (parts.js) {
-    const script = document.createElement('script');
-    script.textContent = parts.js;
-    document.body.append(script);
+    const cleanupUrl = (url) => {
+      try {
+        if (url) {
+          URL.revokeObjectURL(url);
+        }
+      } catch (error) {
+        // Ignore cleanup failures.
+      }
+    };
+
+    const appendInlineScript = () => {
+      try {
+        const script = document.createElement('script');
+        if (parts.module) {
+          script.type = 'module';
+        } else if ('async' in script) {
+          script.async = false;
+        }
+        script.textContent = parts.js;
+        document.body.append(script);
+      } catch (error) {
+        console.error('Failed to append activity script element', error);
+      }
+    };
+
+    const appendBlobScript = () => {
+      try {
+        if (typeof Blob !== 'function' || typeof URL?.createObjectURL !== 'function') {
+          return false;
+        }
+
+        const blob = new Blob([parts.js], { type: 'text/javascript' });
+        const blobUrl = URL.createObjectURL(blob);
+
+        const script = document.createElement('script');
+        if (parts.module) {
+          script.type = 'module';
+        } else if ('async' in script) {
+          script.async = false;
+        }
+        script.src = blobUrl;
+
+        const handleLoad = () => cleanupUrl(blobUrl);
+        const handleError = (event) => {
+          cleanupUrl(blobUrl);
+          if (event?.type === 'error') {
+            console.error('Failed to execute activity script from blob URL', event);
+            appendInlineScript();
+          }
+        };
+
+        script.addEventListener('load', handleLoad, { once: true });
+        script.addEventListener('error', handleError, { once: true });
+        document.body.append(script);
+        return true;
+      } catch (error) {
+        console.error('Failed to append activity script from blob URL', error);
+        return false;
+      }
+    };
+
+    if (!appendBlobScript()) {
+      appendInlineScript();
+    }
   }
 
   setupAutoResize(root, container, { embedId });


### PR DESCRIPTION
## Summary
- load embed activity scripts from blob URLs when possible so Canvas LMS executes module payloads without inline permissions
- fall back to inline script injection with synchronous classic execution if blob loading fails
- mirror the blob-based loader and cleanup logic in the docs bundle to keep previews aligned with production

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dcc24b856c832b954ae95d7734b118