### PR TITLE
Load embed activity scripts via blob URLs

### DIFF
--- a/assets/js/activities/wordCloud.js
+++ b/assets/js/activities/wordCloud.js
@@ -959,6 +959,7 @@ const embedTemplate = (data, containerId, context = {}) => {
       }
     }
   `,
+    module: true,
     js: `
     (() => {
       const config = ${serializeForScript(config)};
@@ -1134,7 +1135,7 @@ const embedTemplate = (data, containerId, context = {}) => {
         }
         submitButton.disabled = !activeInput;
         if (!activeInput) {
-          showStatus('Thanks! You\'ve used all your contributions on this device.', 'limit');
+          showStatus("Thanks! You've used all your contributions on this device.", 'limit');
         } else if (!statusEl.hidden && statusEl.dataset.tone === 'limit') {
           clearStatus();
         }

--- a/assets/js/embedViewer.js
+++ b/assets/js/embedViewer.js
@@ -510,9 +510,85 @@ const renderActivity = (root, payload, { embedId } = {}) => {
   document.head.append(style);
 
   if (parts.js) {
-    const script = document.createElement('script');
-    script.textContent = parts.js;
-    document.body.append(script);
+    const createScript = () => {
+      const script = document.createElement('script');
+      if (parts.module) {
+        script.type = 'module';
+      } else if ('async' in script) {
+        script.async = false;
+      }
+      return script;
+    };
+
+    const appendInlineScript = () => {
+      try {
+        const script = createScript();
+        script.textContent = parts.js;
+        document.body.append(script);
+        return true;
+      } catch (error) {
+        console.error('Failed to append activity script element', error);
+        return false;
+      }
+    };
+
+    const appendBlobScript = () => {
+      if (typeof Blob !== 'function' || typeof URL === 'undefined' || typeof URL.createObjectURL !== 'function') {
+        return false;
+      }
+
+      let blobUrl;
+      const cleanupUrl = () => {
+        if (!blobUrl) {
+          return;
+        }
+        try {
+          URL.revokeObjectURL(blobUrl);
+        } catch (error) {
+          // Ignore cleanup failures.
+        }
+        blobUrl = undefined;
+      };
+
+      try {
+        const blob = new Blob([parts.js], { type: 'text/javascript' });
+        blobUrl = URL.createObjectURL(blob);
+
+        const script = createScript();
+        script.src = blobUrl;
+
+        script.addEventListener(
+          'load',
+          () => {
+            cleanupUrl();
+          },
+          { once: true }
+        );
+
+        script.addEventListener(
+          'error',
+          (event) => {
+            cleanupUrl();
+            if (event?.type === 'error') {
+              console.error('Failed to execute activity script from blob URL', event);
+              appendInlineScript();
+            }
+          },
+          { once: true }
+        );
+
+        document.body.append(script);
+        return true;
+      } catch (error) {
+        cleanupUrl();
+        console.error('Failed to append activity script from blob URL', error);
+        return false;
+      }
+    };
+
+    if (!appendBlobScript()) {
+      appendInlineScript();
+    }
   }
 
   setupAutoResize(root, container, { embedId });

--- a/docs/assets/js/activities/wordCloud.js
+++ b/docs/assets/js/activities/wordCloud.js
@@ -959,6 +959,7 @@ const embedTemplate = (data, containerId, context = {}) => {
       }
     }
   `,
+    module: true,
     js: `
     (() => {
       const config = ${serializeForScript(config)};
@@ -1134,7 +1135,7 @@ const embedTemplate = (data, containerId, context = {}) => {
         }
         submitButton.disabled = !activeInput;
         if (!activeInput) {
-          showStatus('Thanks! You\'ve used all your contributions on this device.', 'limit');
+          showStatus("Thanks! You've used all your contributions on this device.", 'limit');
         } else if (!statusEl.hidden && statusEl.dataset.tone === 'limit') {
           clearStatus();
         }

--- a/docs/assets/js/embedViewer.js
+++ b/docs/assets/js/embedViewer.js
@@ -548,9 +548,85 @@ const renderActivity = (root, payload, { embedId } = {}) => {
   document.head.append(style);
 
   if (parts.js) {
-    const script = document.createElement('script');
-    script.textContent = parts.js;
-    document.body.append(script);
+    const createScript = () => {
+      const script = document.createElement('script');
+      if (parts.module) {
+        script.type = 'module';
+      } else if ('async' in script) {
+        script.async = false;
+      }
+      return script;
+    };
+
+    const appendInlineScript = () => {
+      try {
+        const script = createScript();
+        script.textContent = parts.js;
+        document.body.append(script);
+        return true;
+      } catch (error) {
+        console.error('Failed to append activity script element', error);
+        return false;
+      }
+    };
+
+    const appendBlobScript = () => {
+      if (typeof Blob !== 'function' || typeof URL === 'undefined' || typeof URL.createObjectURL !== 'function') {
+        return false;
+      }
+
+      let blobUrl;
+      const cleanupUrl = () => {
+        if (!blobUrl) {
+          return;
+        }
+        try {
+          URL.revokeObjectURL(blobUrl);
+        } catch (error) {
+          // Ignore cleanup failures.
+        }
+        blobUrl = undefined;
+      };
+
+      try {
+        const blob = new Blob([parts.js], { type: 'text/javascript' });
+        blobUrl = URL.createObjectURL(blob);
+
+        const script = createScript();
+        script.src = blobUrl;
+
+        script.addEventListener(
+          'load',
+          () => {
+            cleanupUrl();
+          },
+          { once: true }
+        );
+
+        script.addEventListener(
+          'error',
+          (event) => {
+            cleanupUrl();
+            if (event?.type === 'error') {
+              console.error('Failed to execute activity script from blob URL', event);
+              appendInlineScript();
+            }
+          },
+          { once: true }
+        );
+
+        document.body.append(script);
+        return true;
+      } catch (error) {
+        cleanupUrl();
+        console.error('Failed to append activity script from blob URL', error);
+        return false;
+      }
+    };
+
+    if (!appendBlobScript()) {
+      appendInlineScript();
+    }
   }
 
   setupAutoResize(root, container, { embedId });


### PR DESCRIPTION
## Summary
- load embed activity scripts from blob URLs when possible so Canvas LMS executes module payloads without inline permissions
- fall back to inline script injection with synchronous classic execution if blob loading fails
- mirror the blob-based loader and cleanup logic in the docs bundle to keep previews aligned with production

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dcc24b856c832b954ae95d7734b118