### PR TITLE
Allow runtime Firestore configuration

### DIFF
--- a/assets/js/activities/wordCloud.js
+++ b/assets/js/activities/wordCloud.js
@@ -1,4 +1,5 @@
 import { clone, uid, escapeHtml } from '../utils.js';
+import { getFirebaseConfig, getResponsesCollectionName } from '../firebaseSettings.js';
 
 const DEFAULT_PROMPT = 'What word or short phrase captures your reaction to today\'s lesson?';
 const DEFAULT_INSTRUCTIONS = 'Submit up to three contributions. Watch the cloud grow as classmates share.';
@@ -784,14 +785,8 @@ const embedTemplate = (data, containerId, context = {}) => {
     seedWords: Array.from(seedMap.values())
   };
 
-  const firebaseConfig = {
-    apiKey: 'AIzaSyBLj8Ql3rEOLmIiVW6IDa8uJNGFLNbhA6U',
-    authDomain: 'tdt-sandbox.firebaseapp.com',
-    projectId: 'tdt-sandbox',
-    storageBucket: 'tdt-sandbox.firebasestorage.app',
-    messagingSenderId: '924451875699',
-    appId: '1:924451875699:web:46464d31b27c4c62b3f306'
-  };
+  const firebaseConfig = getFirebaseConfig();
+  const responsesCollection = getResponsesCollectionName();
 
   return {
     html: `
@@ -963,6 +958,7 @@ const embedTemplate = (data, containerId, context = {}) => {
     (() => {
       const config = ${serializeForScript(config)};
       const firebaseConfig = ${serializeForScript(firebaseConfig)};
+      const responsesCollection = ${serializeForScript(responsesCollection)};
       const container = document.getElementById('${containerId}');
       if (!container) return;
       const form = container.querySelector('[data-wordcloud-form]');
@@ -1215,7 +1211,7 @@ const embedTemplate = (data, containerId, context = {}) => {
 
           const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
           const db = getFirestore(app);
-          const docRef = doc(db, 'wordCloudResponses', config.responseId);
+          const docRef = doc(db, responsesCollection, config.responseId);
 
           const snapshot = await getDoc(docRef);
           if (!snapshot.exists()) {

--- a/assets/js/embedViewer.js
+++ b/assets/js/embedViewer.js
@@ -1,4 +1,5 @@
 import { activities } from './activities/index.js';
+import { getFirebaseConfig, getActivitiesCollectionName } from './firebaseSettings.js';
 
 const VIEW_ROOT_ID = 'cd-embed-viewer-root';
 const REQUEST_MESSAGE_TYPE = 'canvas-designer:request-payload';
@@ -7,9 +8,10 @@ const RESIZE_MESSAGE_TYPE = 'canvas-designer:embed-resize';
 const PARENT_RESPONSE_TIMEOUT = 8000;
 const DEFAULT_MIN_HEIGHT = 420;
 
-const FIRESTORE_PROJECT_ID = 'tdt-sandbox';
-const FIRESTORE_COLLECTION = 'canvasDesignerActivities';
-const FIRESTORE_API_KEY = 'AIzaSyBLj8Ql3rEOLmIiVW6IDa8uJNGFLNbhA6U';
+const firebaseConfig = getFirebaseConfig();
+const FIRESTORE_PROJECT_ID = firebaseConfig.projectId || 'tdt-sandbox';
+const FIRESTORE_COLLECTION = getActivitiesCollectionName();
+const FIRESTORE_API_KEY = firebaseConfig.apiKey || 'AIzaSyBLj8Ql3rEOLmIiVW6IDa8uJNGFLNbhA6U';
 const FIRESTORE_BASE_URL = `https://firestore.googleapis.com/v1/projects/${FIRESTORE_PROJECT_ID}/databases/(default)/documents/${FIRESTORE_COLLECTION}`;
 
 const baseStyles = (containerId) => `

--- a/assets/js/firebaseClient.js
+++ b/assets/js/firebaseClient.js
@@ -4,36 +4,15 @@ import {
   getAuth,
   signInWithEmailAndPassword
 } from 'https://www.gstatic.com/firebasejs/10.8.0/firebase-auth.js';
+import { getFirebaseConfig, getServiceAccountConfig } from './firebaseSettings.js';
 
-const firebaseConfig = {
-  apiKey: 'AIzaSyBLj8Ql3rEOLmIiVW6IDa8uJNGFLNbhA6U',
-  authDomain: 'tdt-sandbox.firebaseapp.com',
-  projectId: 'tdt-sandbox',
-  storageBucket: 'tdt-sandbox.firebasestorage.app',
-  messagingSenderId: '924451875699',
-  appId: '1:924451875699:web:46464d31b27c4c62b3f306'
-};
+const firebaseConfig = getFirebaseConfig();
+const { email: SERVICE_USER_EMAIL, password: SERVICE_USER_PASSWORD } = getServiceAccountConfig();
 
 let appInstance;
 let firestoreInstance;
 let authInstance;
 let authReadyPromise;
-
-const decodeBase64 = (value) => {
-  if (typeof value !== 'string') {
-    return '';
-  }
-  if (typeof globalThis !== 'undefined' && typeof globalThis.atob === 'function') {
-    return globalThis.atob(value);
-  }
-  if (typeof Buffer !== 'undefined') {
-    return Buffer.from(value, 'base64').toString('utf-8');
-  }
-  return value;
-};
-
-const SERVICE_USER_EMAIL = 'canvasdesigner-service@tdt-sandbox.firebaseapp.com';
-const SERVICE_USER_PASSWORD = decodeBase64('c2FsdGlzYXNpbg==');
 
 export const getFirebaseApp = () => {
   if (!appInstance) {

--- a/assets/js/firebaseSettings.js
+++ b/assets/js/firebaseSettings.js
@@ -1,0 +1,198 @@
+const DEFAULT_FIREBASE_CONFIG = {
+  apiKey: 'AIzaSyBLj8Ql3rEOLmIiVW6IDa8uJNGFLNbhA6U',
+  authDomain: 'tdt-sandbox.firebaseapp.com',
+  projectId: 'tdt-sandbox',
+  storageBucket: 'tdt-sandbox.firebasestorage.app',
+  messagingSenderId: '924451875699',
+  appId: '1:924451875699:web:46464d31b27c4c62b3f306'
+};
+
+const DEFAULT_SERVICE_ACCOUNT = {
+  email: 'canvasdesigner-service@tdt-sandbox.firebaseapp.com',
+  password: 'saltisasin'
+};
+
+const DEFAULT_COLLECTIONS = {
+  activities: 'canvasDesignerActivities',
+  responses: 'wordCloudResponses'
+};
+
+const sanitiseString = (value) => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  const trimmed = value.trim();
+  return trimmed;
+};
+
+const sanitiseCollectionName = (value) => {
+  const trimmed = sanitiseString(value);
+  if (!trimmed) {
+    return '';
+  }
+  return trimmed.replace(/[^A-Za-z0-9_-]/g, '');
+};
+
+const decodeBase64 = (value) => {
+  if (typeof value !== 'string' || !value) {
+    return '';
+  }
+  if (typeof globalThis !== 'undefined' && typeof globalThis.atob === 'function') {
+    try {
+      return globalThis.atob(value);
+    } catch (error) {
+      return '';
+    }
+  }
+  if (typeof Buffer !== 'undefined') {
+    try {
+      return Buffer.from(value, 'base64').toString('utf-8');
+    } catch (error) {
+      return '';
+    }
+  }
+  return '';
+};
+
+const readEnv = (key) => {
+  if (typeof process === 'undefined' || !process?.env) {
+    return undefined;
+  }
+  const value = process.env[key];
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+};
+
+const mergeDefined = (target, source) => {
+  if (!source || typeof source !== 'object') {
+    return target;
+  }
+  Object.entries(source).forEach(([key, value]) => {
+    if (value === undefined || value === null) {
+      return;
+    }
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (!trimmed) {
+        return;
+      }
+      target[key] = trimmed;
+      return;
+    }
+    target[key] = value;
+  });
+  return target;
+};
+
+export const getFirebaseConfig = () => {
+  const config = { ...DEFAULT_FIREBASE_CONFIG };
+
+  const envJson = readEnv('CANVASDESIGNER_FIREBASE_CONFIG_JSON');
+  if (envJson) {
+    try {
+      const parsed = JSON.parse(envJson);
+      mergeDefined(config, parsed);
+    } catch (error) {
+      console.warn('Invalid CANVASDESIGNER_FIREBASE_CONFIG_JSON value', error);
+    }
+  }
+
+  const envOverrides = {
+    apiKey: readEnv('CANVASDESIGNER_FIREBASE_API_KEY'),
+    authDomain: readEnv('CANVASDESIGNER_FIREBASE_AUTH_DOMAIN'),
+    projectId: readEnv('CANVASDESIGNER_FIREBASE_PROJECT_ID'),
+    storageBucket: readEnv('CANVASDESIGNER_FIREBASE_STORAGE_BUCKET'),
+    messagingSenderId: readEnv('CANVASDESIGNER_FIREBASE_MESSAGING_SENDER_ID'),
+    appId: readEnv('CANVASDESIGNER_FIREBASE_APP_ID')
+  };
+  mergeDefined(config, envOverrides);
+
+  if (typeof window !== 'undefined') {
+    const override = window.CANVASDESIGNER_FIREBASE_CONFIG;
+    if (override && typeof override === 'object') {
+      mergeDefined(config, override);
+    }
+  }
+
+  return config;
+};
+
+export const getServiceAccountConfig = () => {
+  const credentials = { ...DEFAULT_SERVICE_ACCOUNT };
+
+  const envEmail = readEnv('CANVASDESIGNER_FIREBASE_SERVICE_EMAIL');
+  if (envEmail) {
+    credentials.email = envEmail;
+  }
+
+  const envPasswordBase64 = readEnv('CANVASDESIGNER_FIREBASE_SERVICE_PASSWORD_BASE64');
+  if (envPasswordBase64) {
+    const decoded = decodeBase64(envPasswordBase64);
+    if (decoded) {
+      credentials.password = decoded;
+    }
+  } else {
+    const envPassword = readEnv('CANVASDESIGNER_FIREBASE_SERVICE_PASSWORD');
+    if (envPassword) {
+      credentials.password = envPassword;
+    }
+  }
+
+  if (typeof window !== 'undefined') {
+    const override = window.CANVASDESIGNER_FIREBASE_SERVICE_ACCOUNT;
+    if (override && typeof override === 'object') {
+      if (typeof override.email === 'string' && override.email.trim()) {
+        credentials.email = override.email.trim();
+      }
+      if (typeof override.passwordBase64 === 'string' && override.passwordBase64.trim()) {
+        const decoded = decodeBase64(override.passwordBase64.trim());
+        if (decoded) {
+          credentials.password = decoded;
+        }
+      } else if (typeof override.password === 'string' && override.password.trim()) {
+        credentials.password = override.password.trim();
+      }
+    }
+  }
+
+  return credentials;
+};
+
+const getCollectionOverrides = () => {
+  const overrides = { ...DEFAULT_COLLECTIONS };
+
+  const activities = sanitiseCollectionName(readEnv('CANVASDESIGNER_FIRESTORE_ACTIVITIES_COLLECTION'));
+  if (activities) {
+    overrides.activities = activities;
+  }
+  const responses = sanitiseCollectionName(readEnv('CANVASDESIGNER_FIRESTORE_RESPONSES_COLLECTION'));
+  if (responses) {
+    overrides.responses = responses;
+  }
+
+  if (typeof window !== 'undefined') {
+    const runtime = window.CANVASDESIGNER_FIRESTORE_COLLECTIONS;
+    if (runtime && typeof runtime === 'object') {
+      if (typeof runtime.activities === 'string') {
+        const sanitised = sanitiseCollectionName(runtime.activities);
+        if (sanitised) {
+          overrides.activities = sanitised;
+        }
+      }
+      if (typeof runtime.responses === 'string') {
+        const sanitised = sanitiseCollectionName(runtime.responses);
+        if (sanitised) {
+          overrides.responses = sanitised;
+        }
+      }
+    }
+  }
+
+  return overrides;
+};
+
+export const getActivitiesCollectionName = () => getCollectionOverrides().activities;
+export const getResponsesCollectionName = () => getCollectionOverrides().responses;

--- a/assets/js/storage.js
+++ b/assets/js/storage.js
@@ -8,8 +8,9 @@ import {
 } from 'https://www.gstatic.com/firebasejs/10.8.0/firebase-firestore.js';
 import { clone, coalesce } from './utils.js';
 import { getFirestoreDb, ensureAuth } from './firebaseClient.js';
+import { getActivitiesCollectionName } from './firebaseSettings.js';
 
-const COLLECTION_NAME = 'canvasDesignerActivities';
+const COLLECTION_NAME = getActivitiesCollectionName();
 
 const mapSnapshotToProject = (snapshot) => {
   if (!snapshot) return null;

--- a/docs/assets/js/activities/wordCloud.js
+++ b/docs/assets/js/activities/wordCloud.js
@@ -1,4 +1,5 @@
 import { clone, uid, escapeHtml } from '../utils.js';
+import { getFirebaseConfig, getResponsesCollectionName } from '../firebaseSettings.js';
 
 const DEFAULT_PROMPT = 'What word or short phrase captures your reaction to today\'s lesson?';
 const DEFAULT_INSTRUCTIONS = 'Submit up to three contributions. Watch the cloud grow as classmates share.';
@@ -784,14 +785,8 @@ const embedTemplate = (data, containerId, context = {}) => {
     seedWords: Array.from(seedMap.values())
   };
 
-  const firebaseConfig = {
-    apiKey: 'AIzaSyBLj8Ql3rEOLmIiVW6IDa8uJNGFLNbhA6U',
-    authDomain: 'tdt-sandbox.firebaseapp.com',
-    projectId: 'tdt-sandbox',
-    storageBucket: 'tdt-sandbox.firebasestorage.app',
-    messagingSenderId: '924451875699',
-    appId: '1:924451875699:web:46464d31b27c4c62b3f306'
-  };
+  const firebaseConfig = getFirebaseConfig();
+  const responsesCollection = getResponsesCollectionName();
 
   return {
     html: `
@@ -963,6 +958,7 @@ const embedTemplate = (data, containerId, context = {}) => {
     (() => {
       const config = ${serializeForScript(config)};
       const firebaseConfig = ${serializeForScript(firebaseConfig)};
+      const responsesCollection = ${serializeForScript(responsesCollection)};
       const container = document.getElementById('${containerId}');
       if (!container) return;
       const form = container.querySelector('[data-wordcloud-form]');
@@ -1215,7 +1211,7 @@ const embedTemplate = (data, containerId, context = {}) => {
 
           const app = getApps().length ? getApps()[0] : initializeApp(firebaseConfig);
           const db = getFirestore(app);
-          const docRef = doc(db, 'wordCloudResponses', config.responseId);
+          const docRef = doc(db, responsesCollection, config.responseId);
 
           const snapshot = await getDoc(docRef);
           if (!snapshot.exists()) {

--- a/docs/assets/js/embedViewer.js
+++ b/docs/assets/js/embedViewer.js
@@ -1,4 +1,5 @@
 import { activities } from './activities/index.js';
+import { getFirebaseConfig, getActivitiesCollectionName } from './firebaseSettings.js';
 
 const VIEW_ROOT_ID = 'cd-embed-viewer-root';
 const REQUEST_MESSAGE_TYPE = 'canvas-designer:request-payload';
@@ -8,9 +9,10 @@ const REQUEST_RESIZE_MESSAGE_TYPE = 'canvas-designer:request-embed-resize';
 const PARENT_RESPONSE_TIMEOUT = 8000;
 const DEFAULT_MIN_HEIGHT = 420;
 
-const FIRESTORE_PROJECT_ID = 'tdt-sandbox';
-const FIRESTORE_COLLECTION = 'canvasDesignerActivities';
-const FIRESTORE_API_KEY = 'AIzaSyBLj8Ql3rEOLmIiVW6IDa8uJNGFLNbhA6U';
+const firebaseConfig = getFirebaseConfig();
+const FIRESTORE_PROJECT_ID = firebaseConfig.projectId || 'tdt-sandbox';
+const FIRESTORE_COLLECTION = getActivitiesCollectionName();
+const FIRESTORE_API_KEY = firebaseConfig.apiKey || 'AIzaSyBLj8Ql3rEOLmIiVW6IDa8uJNGFLNbhA6U';
 const FIRESTORE_BASE_URL = `https://firestore.googleapis.com/v1/projects/${FIRESTORE_PROJECT_ID}/databases/(default)/documents/${FIRESTORE_COLLECTION}`;
 
 const baseStyles = (containerId) => `

--- a/docs/assets/js/firebaseSettings.js
+++ b/docs/assets/js/firebaseSettings.js
@@ -1,0 +1,198 @@
+const DEFAULT_FIREBASE_CONFIG = {
+  apiKey: 'AIzaSyBLj8Ql3rEOLmIiVW6IDa8uJNGFLNbhA6U',
+  authDomain: 'tdt-sandbox.firebaseapp.com',
+  projectId: 'tdt-sandbox',
+  storageBucket: 'tdt-sandbox.firebasestorage.app',
+  messagingSenderId: '924451875699',
+  appId: '1:924451875699:web:46464d31b27c4c62b3f306'
+};
+
+const DEFAULT_SERVICE_ACCOUNT = {
+  email: 'canvasdesigner-service@tdt-sandbox.firebaseapp.com',
+  password: 'saltisasin'
+};
+
+const DEFAULT_COLLECTIONS = {
+  activities: 'canvasDesignerActivities',
+  responses: 'wordCloudResponses'
+};
+
+const sanitiseString = (value) => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  const trimmed = value.trim();
+  return trimmed;
+};
+
+const sanitiseCollectionName = (value) => {
+  const trimmed = sanitiseString(value);
+  if (!trimmed) {
+    return '';
+  }
+  return trimmed.replace(/[^A-Za-z0-9_-]/g, '');
+};
+
+const decodeBase64 = (value) => {
+  if (typeof value !== 'string' || !value) {
+    return '';
+  }
+  if (typeof globalThis !== 'undefined' && typeof globalThis.atob === 'function') {
+    try {
+      return globalThis.atob(value);
+    } catch (error) {
+      return '';
+    }
+  }
+  if (typeof Buffer !== 'undefined') {
+    try {
+      return Buffer.from(value, 'base64').toString('utf-8');
+    } catch (error) {
+      return '';
+    }
+  }
+  return '';
+};
+
+const readEnv = (key) => {
+  if (typeof process === 'undefined' || !process?.env) {
+    return undefined;
+  }
+  const value = process.env[key];
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+};
+
+const mergeDefined = (target, source) => {
+  if (!source || typeof source !== 'object') {
+    return target;
+  }
+  Object.entries(source).forEach(([key, value]) => {
+    if (value === undefined || value === null) {
+      return;
+    }
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      if (!trimmed) {
+        return;
+      }
+      target[key] = trimmed;
+      return;
+    }
+    target[key] = value;
+  });
+  return target;
+};
+
+export const getFirebaseConfig = () => {
+  const config = { ...DEFAULT_FIREBASE_CONFIG };
+
+  const envJson = readEnv('CANVASDESIGNER_FIREBASE_CONFIG_JSON');
+  if (envJson) {
+    try {
+      const parsed = JSON.parse(envJson);
+      mergeDefined(config, parsed);
+    } catch (error) {
+      console.warn('Invalid CANVASDESIGNER_FIREBASE_CONFIG_JSON value', error);
+    }
+  }
+
+  const envOverrides = {
+    apiKey: readEnv('CANVASDESIGNER_FIREBASE_API_KEY'),
+    authDomain: readEnv('CANVASDESIGNER_FIREBASE_AUTH_DOMAIN'),
+    projectId: readEnv('CANVASDESIGNER_FIREBASE_PROJECT_ID'),
+    storageBucket: readEnv('CANVASDESIGNER_FIREBASE_STORAGE_BUCKET'),
+    messagingSenderId: readEnv('CANVASDESIGNER_FIREBASE_MESSAGING_SENDER_ID'),
+    appId: readEnv('CANVASDESIGNER_FIREBASE_APP_ID')
+  };
+  mergeDefined(config, envOverrides);
+
+  if (typeof window !== 'undefined') {
+    const override = window.CANVASDESIGNER_FIREBASE_CONFIG;
+    if (override && typeof override === 'object') {
+      mergeDefined(config, override);
+    }
+  }
+
+  return config;
+};
+
+export const getServiceAccountConfig = () => {
+  const credentials = { ...DEFAULT_SERVICE_ACCOUNT };
+
+  const envEmail = readEnv('CANVASDESIGNER_FIREBASE_SERVICE_EMAIL');
+  if (envEmail) {
+    credentials.email = envEmail;
+  }
+
+  const envPasswordBase64 = readEnv('CANVASDESIGNER_FIREBASE_SERVICE_PASSWORD_BASE64');
+  if (envPasswordBase64) {
+    const decoded = decodeBase64(envPasswordBase64);
+    if (decoded) {
+      credentials.password = decoded;
+    }
+  } else {
+    const envPassword = readEnv('CANVASDESIGNER_FIREBASE_SERVICE_PASSWORD');
+    if (envPassword) {
+      credentials.password = envPassword;
+    }
+  }
+
+  if (typeof window !== 'undefined') {
+    const override = window.CANVASDESIGNER_FIREBASE_SERVICE_ACCOUNT;
+    if (override && typeof override === 'object') {
+      if (typeof override.email === 'string' && override.email.trim()) {
+        credentials.email = override.email.trim();
+      }
+      if (typeof override.passwordBase64 === 'string' && override.passwordBase64.trim()) {
+        const decoded = decodeBase64(override.passwordBase64.trim());
+        if (decoded) {
+          credentials.password = decoded;
+        }
+      } else if (typeof override.password === 'string' && override.password.trim()) {
+        credentials.password = override.password.trim();
+      }
+    }
+  }
+
+  return credentials;
+};
+
+const getCollectionOverrides = () => {
+  const overrides = { ...DEFAULT_COLLECTIONS };
+
+  const activities = sanitiseCollectionName(readEnv('CANVASDESIGNER_FIRESTORE_ACTIVITIES_COLLECTION'));
+  if (activities) {
+    overrides.activities = activities;
+  }
+  const responses = sanitiseCollectionName(readEnv('CANVASDESIGNER_FIRESTORE_RESPONSES_COLLECTION'));
+  if (responses) {
+    overrides.responses = responses;
+  }
+
+  if (typeof window !== 'undefined') {
+    const runtime = window.CANVASDESIGNER_FIRESTORE_COLLECTIONS;
+    if (runtime && typeof runtime === 'object') {
+      if (typeof runtime.activities === 'string') {
+        const sanitised = sanitiseCollectionName(runtime.activities);
+        if (sanitised) {
+          overrides.activities = sanitised;
+        }
+      }
+      if (typeof runtime.responses === 'string') {
+        const sanitised = sanitiseCollectionName(runtime.responses);
+        if (sanitised) {
+          overrides.responses = sanitised;
+        }
+      }
+    }
+  }
+
+  return overrides;
+};
+
+export const getActivitiesCollectionName = () => getCollectionOverrides().activities;
+export const getResponsesCollectionName = () => getCollectionOverrides().responses;

--- a/docs/firebase-setup.md
+++ b/docs/firebase-setup.md
@@ -30,6 +30,16 @@ The `firestore.rules` file restricts document writes in the `canvasDesignerActiv
 - To encode a new password locally, run `node -e "console.log(Buffer.from('<new-password>', 'utf8').toString('base64'))"` and replace the encoded value in the code.
 - After updating the code, redeploy the site so the new password takes effect.
 
+### Runtime overrides
+
+If your deployment uses different Firebase projects or Firestore collection names, set any of the following configuration hooks before loading the app or viewer:
+
+- `window.CANVASDESIGNER_FIREBASE_CONFIG` – object containing Firebase web config keys (`apiKey`, `projectId`, etc.).
+- `window.CANVASDESIGNER_FIREBASE_SERVICE_ACCOUNT` – object with the service `email` plus either `password` or `passwordBase64`.
+- `window.CANVASDESIGNER_FIRESTORE_COLLECTIONS` – object with `activities` and `responses` collection names.
+
+For scripted deployments, export the matching environment variables instead (`CANVASDESIGNER_FIREBASE_PROJECT_ID`, `CANVASDESIGNER_FIRESTORE_ACTIVITIES_COLLECTION`, and so on). The authoring app, hosted viewer, and word cloud embed all read from these hooks so they stay aligned with your Firestore rules.
+
 ## 5. Embedding in Canvas
 1. In the app, build your activity and open the **Embed code** panel.
 2. Click **Copy** to copy the generated snippet.


### PR DESCRIPTION
## Summary
- add a shared firebaseSettings helper so deployments can override Firebase config, service credentials, and collection names
- update storage, embed viewer, and word cloud runtime to consume the shared configuration including the responses collection
- document the new runtime and environment override hooks in the Firebase setup guide

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dcf46e0708832ba676ec68a4f20c63