### PR TITLE
Improve word cloud input sanitization

### DIFF
--- a/assets/js/activities/wordCloud.js
+++ b/assets/js/activities/wordCloud.js
@@ -545,6 +545,7 @@ const renderPreview = (container, data, options = {}) => {
   };
 
   const sanitizeWordPattern = /[^\p{L}\p{N}\s'-]/gu;
+  const allowedCharacterPattern = /[\p{L}\p{N}\s'-]/u;
 
   const normaliseWord = (value) => {
     if (typeof value !== 'string') {
@@ -554,7 +555,8 @@ const renderPreview = (container, data, options = {}) => {
     if (!trimmed) {
       return '';
     }
-    const cleaned = trimmed.replace(sanitizeWordPattern, '');
+    const sanitized = trimmed.replace(sanitizeWordPattern, '');
+    const cleaned = Array.from(sanitized).filter((char) => allowedCharacterPattern.test(char)).join('');
     return cleaned.slice(0, 36);
   };
 
@@ -1041,6 +1043,7 @@ const embedTemplate = (data, containerId, context = {}) => {
       };
 
       const sanitizeWordPattern = /[^\p{L}\p{N}\s'-]/gu;
+      const allowedCharacterPattern = /[\p{L}\p{N}\s'-]/u;
 
       const slotInputs = [];
       let activeInput = null;
@@ -1072,7 +1075,8 @@ const embedTemplate = (data, containerId, context = {}) => {
         if (!trimmed) {
           return '';
         }
-        const cleaned = trimmed.replace(sanitizeWordPattern, '');
+        const sanitized = trimmed.replace(sanitizeWordPattern, '');
+        const cleaned = Array.from(sanitized).filter((char) => allowedCharacterPattern.test(char)).join('');
         return cleaned.slice(0, 36);
       };
 

--- a/docs/assets/js/activities/wordCloud.js
+++ b/docs/assets/js/activities/wordCloud.js
@@ -544,6 +544,8 @@ const renderPreview = (container, data, options = {}) => {
     return palette[paletteIndex];
   };
 
+  const allowedCharacterPattern = /[\p{L}\p{N}\s'-]/u;
+
   const normaliseWord = (value) => {
     if (typeof value !== 'string') {
       return '';
@@ -552,7 +554,9 @@ const renderPreview = (container, data, options = {}) => {
     if (!trimmed) {
       return '';
     }
-    const cleaned = trimmed.replace(/[^\p{L}\p{N}\s'-]/gu, '');
+    const cleaned = Array.from(trimmed)
+      .filter((char) => allowedCharacterPattern.test(char))
+      .join('');
     return cleaned.slice(0, 36);
   };
 
@@ -1061,6 +1065,8 @@ const embedTemplate = (data, containerId, context = {}) => {
         }
       };
 
+      const allowedCharacterPattern = /[\p{L}\p{N}\s'-]/u;
+
       const normaliseWord = (value) => {
         if (typeof value !== 'string') {
           return '';
@@ -1069,7 +1075,9 @@ const embedTemplate = (data, containerId, context = {}) => {
         if (!trimmed) {
           return '';
         }
-        const cleaned = trimmed.replace(/[^\p{L}\p{N}\s'-]/gu, '');
+        const cleaned = Array.from(trimmed)
+          .filter((char) => allowedCharacterPattern.test(char))
+          .join('');
         return cleaned.slice(0, 36);
       };
 


### PR DESCRIPTION
## Summary
- add Unicode-aware allowed character filtering to the word cloud preview and embed scripts
- mirror the sanitisation updates in the published docs bundle

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ddb7d2f44c832b8699faebf731b264